### PR TITLE
chore: Add ESLint and Prettier configuration

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+dist/
+node_modules/
+package-lock.json
+*.md

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "printWidth": 100
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,28 @@
+import eslint from "@eslint/js";
+import tseslint from "typescript-eslint";
+import eslintConfigPrettier from "eslint-config-prettier";
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.recommended,
+  eslintConfigPrettier,
+  {
+    ignores: ["dist/", "node_modules/", "*.js", "!eslint.config.js"],
+  },
+  {
+    files: ["src/**/*.ts"],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
+      "@typescript-eslint/no-explicit-any": "warn",
+    },
+  }
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,10 +18,15 @@
         "logicapps-mcp": "dist/index.js"
       },
       "devDependencies": {
+        "@eslint/js": "^9.39.2",
         "@types/express": "^5.0.6",
         "@types/node": "^20.0.0",
+        "eslint": "^9.39.2",
+        "eslint-config-prettier": "^10.1.8",
+        "prettier": "^3.7.4",
         "rimraf": "^5.0.0",
         "typescript": "^5.3.0",
+        "typescript-eslint": "^8.51.0",
         "vitest": "^4.0.16"
       },
       "engines": {
@@ -639,6 +644,206 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
+      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+      "dev": true,
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
+      "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.2",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
+      "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@fastify/busboy": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
@@ -657,6 +862,54 @@
       },
       "peerDependencies": {
         "hono": "^4"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -1122,6 +1375,12 @@
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
       "dev": true
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true
+    },
     "node_modules/@types/node": {
       "version": "20.19.27",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.27.tgz",
@@ -1161,6 +1420,225 @@
       "dependencies": {
         "@types/http-errors": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.51.0.tgz",
+      "integrity": "sha512-XtssGWJvypyM2ytBnSnKtHYOGT+4ZwTnBVl36TA4nRO2f4PRNGz5/1OszHzcZCvcBMh+qb7I06uoCmLTRdR9og==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "8.51.0",
+        "@typescript-eslint/type-utils": "8.51.0",
+        "@typescript-eslint/utils": "8.51.0",
+        "@typescript-eslint/visitor-keys": "8.51.0",
+        "ignore": "^7.0.0",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.51.0",
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.51.0.tgz",
+      "integrity": "sha512-3xP4XzzDNQOIqBMWogftkwxhg5oMKApqY0BAflmLZiFYHqyhSOxv/cd/zPQLTcCXr4AkaKb25joocY0BD1WC6A==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.51.0",
+        "@typescript-eslint/types": "8.51.0",
+        "@typescript-eslint/typescript-estree": "8.51.0",
+        "@typescript-eslint/visitor-keys": "8.51.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.51.0.tgz",
+      "integrity": "sha512-Luv/GafO07Z7HpiI7qeEW5NW8HUtZI/fo/kE0YbtQEFpJRUuR0ajcWfCE5bnMvL7QQFrmT/odMe8QZww8X2nfQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.51.0",
+        "@typescript-eslint/types": "^8.51.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.51.0.tgz",
+      "integrity": "sha512-JhhJDVwsSx4hiOEQPeajGhCWgBMBwVkxC/Pet53EpBVs7zHHtayKefw1jtPaNRXpI9RA2uocdmpdfE7T+NrizA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "8.51.0",
+        "@typescript-eslint/visitor-keys": "8.51.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.51.0.tgz",
+      "integrity": "sha512-Qi5bSy/vuHeWyir2C8u/uqGMIlIDu8fuiYWv48ZGlZ/k+PRPHtaAu7erpc7p5bzw2WNNSniuxoMSO4Ar6V9OXw==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.51.0.tgz",
+      "integrity": "sha512-0XVtYzxnobc9K0VU7wRWg1yiUrw4oQzexCG2V2IDxxCxhqBMSMbjB+6o91A+Uc0GWtgjCa3Y8bi7hwI0Tu4n5Q==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "8.51.0",
+        "@typescript-eslint/typescript-estree": "8.51.0",
+        "@typescript-eslint/utils": "8.51.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^2.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.51.0.tgz",
+      "integrity": "sha512-TizAvWYFM6sSscmEakjY3sPqGwxZRSywSsPEiuZF6d5GmGD9Gvlsv0f6N8FvAAA0CD06l3rIcWNbsN1e5F/9Ag==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.51.0.tgz",
+      "integrity": "sha512-1qNjGqFRmlq0VW5iVlcyHBbCjPB7y6SxpBkrbhNWMy/65ZoncXCEPJxkRZL8McrseNH6lFhaxCIaX+vBuFnRng==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.51.0",
+        "@typescript-eslint/tsconfig-utils": "8.51.0",
+        "@typescript-eslint/types": "8.51.0",
+        "@typescript-eslint/visitor-keys": "8.51.0",
+        "debug": "^4.3.4",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.51.0.tgz",
+      "integrity": "sha512-11rZYxSe0zabiKaCP2QAwRf/dnmgFgvTmeDTtZvUvXG3UuAdg/GU02NExmmIXzz3vLGgMdtrIosI84jITQOxUA==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/scope-manager": "8.51.0",
+        "@typescript-eslint/types": "8.51.0",
+        "@typescript-eslint/typescript-estree": "8.51.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.51.0.tgz",
+      "integrity": "sha512-mM/JRQOzhVN1ykejrvwnBRV3+7yTKK8tVANVN3o1O0t0v7o+jqdVu9crPy5Y9dov15TJk/FTIgoUGHrTOVL3Zg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "8.51.0",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@typespec/ts-http-runtime": {
@@ -1300,6 +1778,27 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -1366,6 +1865,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -1475,6 +1980,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.1.tgz",
@@ -1483,6 +1997,37 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/color-convert": {
@@ -1504,6 +2049,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "node_modules/content-disposition": {
       "version": "1.0.1",
@@ -1588,6 +2139,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
     },
     "node_modules/default-browser": {
       "version": "5.4.0",
@@ -1771,6 +2328,214 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.2",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
+      "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.1",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.39.2",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -1779,6 +2544,15 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/etag": {
@@ -1884,6 +2658,18 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -1918,6 +2704,18 @@
         }
       }
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -1938,6 +2736,41 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -2056,6 +2889,30 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -2066,6 +2923,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/has-symbols": {
@@ -2162,6 +3028,40 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -2191,6 +3091,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -2199,6 +3108,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-inside-container": {
@@ -2269,6 +3190,24 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -2280,6 +3219,12 @@
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.3",
@@ -2321,6 +3266,43 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -2350,6 +3332,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
@@ -2484,6 +3472,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -2563,12 +3557,71 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -2577,6 +3630,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-key": {
@@ -2680,6 +3742,30 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
+      "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -2691,6 +3777,15 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -2739,6 +3834,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/rimraf": {
@@ -3163,6 +4267,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -3216,10 +4344,34 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.3.0.tgz",
+      "integrity": "sha512-6eg3Y9SF7SsAvGzRHQvvc1skDAhwI4YQ32ui1scxD1Ccr0G5qIIbUBT3pFTKX8kmWIQClHobtUdNuaBgwdfdWg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/type-is": {
       "version": "2.0.1",
@@ -3249,6 +4401,29 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/typescript-eslint": {
+      "version": "8.51.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.51.0.tgz",
+      "integrity": "sha512-jh8ZuM5oEh2PSdyQG9YAEM1TCGuWenLSuSUhf/irbVUNW9O5FhbFVONviN2TgMTBnUmyHv7E56rYnfLZK6TkiA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.51.0",
+        "@typescript-eslint/parser": "8.51.0",
+        "@typescript-eslint/typescript-estree": "8.51.0",
+        "@typescript-eslint/utils": "8.51.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
     "node_modules/undici": {
       "version": "5.29.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
@@ -3274,6 +4449,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/uuid": {
@@ -3478,6 +4662,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
@@ -3591,6 +4784,18 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
     "clean": "rimraf dist",
     "test": "vitest run",
     "test:watch": "vitest",
+    "lint": "eslint src/",
+    "lint:fix": "eslint src/ --fix",
+    "format": "prettier --write src/",
+    "format:check": "prettier --check src/",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
@@ -35,10 +39,15 @@
     "express": "^5.2.1"
   },
   "devDependencies": {
+    "@eslint/js": "^9.39.2",
     "@types/express": "^5.0.6",
     "@types/node": "^20.0.0",
+    "eslint": "^9.39.2",
+    "eslint-config-prettier": "^10.1.8",
+    "prettier": "^3.7.4",
     "rimraf": "^5.0.0",
     "typescript": "^5.3.0",
+    "typescript-eslint": "^8.51.0",
     "vitest": "^4.0.16"
   },
   "engines": {

--- a/src/auth/azureCli.test.ts
+++ b/src/auth/azureCli.test.ts
@@ -34,14 +34,12 @@ describe("azureCli", () => {
         tokenType: "Bearer",
       };
 
-      mockExec.mockImplementation(
-        (_cmd: unknown, callback?: unknown) => {
-          if (typeof callback === "function") {
-            callback(null, { stdout: JSON.stringify(mockResponse), stderr: "" });
-          }
-          return {} as ReturnType<typeof exec>;
+      mockExec.mockImplementation((_cmd: unknown, callback?: unknown) => {
+        if (typeof callback === "function") {
+          callback(null, { stdout: JSON.stringify(mockResponse), stderr: "" });
         }
-      );
+        return {} as ReturnType<typeof exec>;
+      });
 
       const token = await getAzureCliToken();
 
@@ -54,34 +52,26 @@ describe("azureCli", () => {
 
     it("should throw when Azure CLI is not installed", async () => {
       const error = new Error("ENOENT: command not found");
-      mockExec.mockImplementation(
-        (_cmd: unknown, callback?: unknown) => {
-          if (typeof callback === "function") {
-            callback(error, "", "");
-          }
-          return {} as ReturnType<typeof exec>;
+      mockExec.mockImplementation((_cmd: unknown, callback?: unknown) => {
+        if (typeof callback === "function") {
+          callback(error, "", "");
         }
-      );
+        return {} as ReturnType<typeof exec>;
+      });
 
-      await expect(getAzureCliToken()).rejects.toThrow(
-        "Azure CLI is not installed"
-      );
+      await expect(getAzureCliToken()).rejects.toThrow("Azure CLI is not installed");
     });
 
     it("should throw when user is not logged in", async () => {
       const error = new Error("Please run 'az login' to setup account");
-      mockExec.mockImplementation(
-        (_cmd: unknown, callback?: unknown) => {
-          if (typeof callback === "function") {
-            callback(error, "", "");
-          }
-          return {} as ReturnType<typeof exec>;
+      mockExec.mockImplementation((_cmd: unknown, callback?: unknown) => {
+        if (typeof callback === "function") {
+          callback(error, "", "");
         }
-      );
+        return {} as ReturnType<typeof exec>;
+      });
 
-      await expect(getAzureCliToken()).rejects.toThrow(
-        "Not logged in to Azure CLI"
-      );
+      await expect(getAzureCliToken()).rejects.toThrow("Not logged in to Azure CLI");
     });
 
     it("should use custom resource when provided", async () => {
@@ -94,15 +84,13 @@ describe("azureCli", () => {
       };
 
       let capturedCommand = "";
-      mockExec.mockImplementation(
-        (cmd: unknown, callback?: unknown) => {
-          capturedCommand = cmd as string;
-          if (typeof callback === "function") {
-            callback(null, { stdout: JSON.stringify(mockResponse), stderr: "" });
-          }
-          return {} as ReturnType<typeof exec>;
+      mockExec.mockImplementation((cmd: unknown, callback?: unknown) => {
+        capturedCommand = cmd as string;
+        if (typeof callback === "function") {
+          callback(null, { stdout: JSON.stringify(mockResponse), stderr: "" });
         }
-      );
+        return {} as ReturnType<typeof exec>;
+      });
 
       await getAzureCliToken("https://vault.azure.net");
 
@@ -121,14 +109,12 @@ describe("azureCli", () => {
         tokenType: "Bearer",
       };
 
-      mockExec.mockImplementation(
-        (_cmd: unknown, callback?: unknown) => {
-          if (typeof callback === "function") {
-            callback(null, { stdout: JSON.stringify(mockResponse), stderr: "" });
-          }
-          return {} as ReturnType<typeof exec>;
+      mockExec.mockImplementation((_cmd: unknown, callback?: unknown) => {
+        if (typeof callback === "function") {
+          callback(null, { stdout: JSON.stringify(mockResponse), stderr: "" });
         }
-      );
+        return {} as ReturnType<typeof exec>;
+      });
 
       const result = await checkAzureCliAuth();
 
@@ -140,14 +126,12 @@ describe("azureCli", () => {
 
     it("should return loggedIn false when not authenticated", async () => {
       const error = new Error("Please run 'az login'");
-      mockExec.mockImplementation(
-        (_cmd: unknown, callback?: unknown) => {
-          if (typeof callback === "function") {
-            callback(error, "", "");
-          }
-          return {} as ReturnType<typeof exec>;
+      mockExec.mockImplementation((_cmd: unknown, callback?: unknown) => {
+        if (typeof callback === "function") {
+          callback(error, "", "");
         }
-      );
+        return {} as ReturnType<typeof exec>;
+      });
 
       const result = await checkAzureCliAuth();
 

--- a/src/auth/azureCli.ts
+++ b/src/auth/azureCli.ts
@@ -47,8 +47,7 @@ export async function getAzureCliToken(
       tokenType: response.tokenType,
     };
   } catch (error) {
-    const errorMessage =
-      error instanceof Error ? error.message : String(error);
+    const errorMessage = error instanceof Error ? error.message : String(error);
 
     if (errorMessage.includes("ENOENT") || errorMessage.includes("not found")) {
       throw new McpError(
@@ -62,10 +61,7 @@ export async function getAzureCliToken(
       errorMessage.includes("not logged in") ||
       errorMessage.includes("AADSTS")
     ) {
-      throw new McpError(
-        "AuthenticationError",
-        "Not logged in to Azure CLI. Please run: az login"
-      );
+      throw new McpError("AuthenticationError", "Not logged in to Azure CLI. Please run: az login");
     }
 
     throw new McpError(

--- a/src/auth/azureIdentity.ts
+++ b/src/auth/azureIdentity.ts
@@ -49,31 +49,26 @@ export async function getToken(
     cachedScope = scope;
 
     if (!cachedToken) {
-      throw new McpError(
-        "AuthenticationError",
-        "Failed to get access token - no token returned"
-      );
+      throw new McpError("AuthenticationError", "Failed to get access token - no token returned");
     }
 
     return cachedToken.token;
   } catch (error) {
-    const errorMessage =
-      error instanceof Error ? error.message : String(error);
+    const errorMessage = error instanceof Error ? error.message : String(error);
 
     // Provide helpful error messages
-    if (errorMessage.includes("EnvironmentCredential") ||
-        errorMessage.includes("ManagedIdentityCredential") ||
-        errorMessage.includes("AzureCliCredential")) {
+    if (
+      errorMessage.includes("EnvironmentCredential") ||
+      errorMessage.includes("ManagedIdentityCredential") ||
+      errorMessage.includes("AzureCliCredential")
+    ) {
       throw new McpError(
         "AuthenticationError",
         `Azure authentication failed. Locally, run 'az login'. In Azure, ensure Managed Identity is configured. Details: ${errorMessage}`
       );
     }
 
-    throw new McpError(
-      "AuthenticationError",
-      `Failed to get Azure access token: ${errorMessage}`
-    );
+    throw new McpError("AuthenticationError", `Failed to get Azure access token: ${errorMessage}`);
   }
 }
 

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -4,18 +4,11 @@
  */
 
 // Legacy Azure CLI exports (kept for backwards compatibility)
-export {
-  getAzureCliToken,
-  checkAzureCliAuth,
-} from "./azureCli.js";
+export { getAzureCliToken, checkAzureCliAuth } from "./azureCli.js";
 export type { AzureCliToken } from "./azureCli.js";
 
 // New Azure Identity exports (recommended)
-export {
-  getToken,
-  checkAuth,
-  clearCache,
-} from "./azureIdentity.js";
+export { getToken, checkAuth, clearCache } from "./azureIdentity.js";
 
 // Token manager (uses Azure Identity internally)
 export {

--- a/src/config/clouds.test.ts
+++ b/src/config/clouds.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import {
-  AZURE_CLOUDS,
-  getCloudEndpoints,
-  AzureCloudEndpoints,
-} from "./clouds.js";
+import { AZURE_CLOUDS, getCloudEndpoints, AzureCloudEndpoints } from "./clouds.js";
 
 describe("clouds", () => {
   describe("AZURE_CLOUDS", () => {
@@ -13,9 +9,7 @@ describe("clouds", () => {
       expect(AZURE_CLOUDS.AzurePublic.authentication.loginEndpoint).toBe(
         "https://login.microsoftonline.com"
       );
-      expect(AZURE_CLOUDS.AzurePublic.resourceManager).toBe(
-        "https://management.azure.com"
-      );
+      expect(AZURE_CLOUDS.AzurePublic.resourceManager).toBe("https://management.azure.com");
     });
 
     it("should have AzureGovernment cloud configuration", () => {
@@ -95,9 +89,7 @@ describe("clouds", () => {
     });
 
     it("should throw for unknown cloud name", () => {
-      expect(() => getCloudEndpoints("UnknownCloud")).toThrow(
-        /Unknown Azure cloud: UnknownCloud/
-      );
+      expect(() => getCloudEndpoints("UnknownCloud")).toThrow(/Unknown Azure cloud: UnknownCloud/);
     });
   });
 });

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -5,10 +5,7 @@
 import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import {
-  AzureCloudEndpoints,
-  getCloudEndpoints,
-} from "./clouds.js";
+import { AzureCloudEndpoints, getCloudEndpoints } from "./clouds.js";
 
 export interface LogicAppsMcpSettings {
   tenantId: string;
@@ -49,13 +46,10 @@ export async function loadSettings(): Promise<LogicAppsMcpSettings> {
 
   return {
     tenantId: process.env.AZURE_TENANT_ID ?? configFile.tenantId ?? "common",
-    clientId:
-      process.env.AZURE_CLIENT_ID ?? configFile.clientId ?? DEFAULT_CLIENT_ID,
+    clientId: process.env.AZURE_CLIENT_ID ?? configFile.clientId ?? DEFAULT_CLIENT_ID,
     cloud,
-    defaultSubscriptionId:
-      process.env.AZURE_SUBSCRIPTION_ID ?? configFile.defaultSubscriptionId,
-    logLevel:
-      (process.env.LOGICAPPS_MCP_LOG_LEVEL as LogicAppsMcpSettings["logLevel"]) ?? "info",
+    defaultSubscriptionId: process.env.AZURE_SUBSCRIPTION_ID ?? configFile.defaultSubscriptionId,
+    logLevel: (process.env.LOGICAPPS_MCP_LOG_LEVEL as LogicAppsMcpSettings["logLevel"]) ?? "info",
     cacheTtlSeconds: parseInt(process.env.LOGICAPPS_MCP_CACHE_TTL ?? "300", 10),
   };
 }

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -12,17 +12,17 @@
  * No fallback to Managed Identity - user token is always required.
  */
 
-import {
-  app,
-  HttpRequest,
-  HttpResponseInit,
-  InvocationContext,
-} from "@azure/functions";
+import { app, HttpRequest, HttpResponseInit, InvocationContext } from "@azure/functions";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { registerTools } from "../server.js";
 import { loadSettings } from "../config/index.js";
-import { setSettings, initializeAuth, setPassthroughToken, clearPassthroughToken } from "../auth/index.js";
+import {
+  setSettings,
+  initializeAuth,
+  setPassthroughToken,
+  clearPassthroughToken,
+} from "../auth/index.js";
 
 let initialized = false;
 
@@ -53,9 +53,7 @@ function createMcpServer(): Server {
 /**
  * Convert Web Standard Response to Azure Functions HttpResponseInit.
  */
-async function convertResponse(
-  response: Response
-): Promise<HttpResponseInit> {
+async function convertResponse(response: Response): Promise<HttpResponseInit> {
   const headers: Record<string, string> = {};
   response.headers.forEach((value, key) => {
     headers[key] = value;
@@ -82,7 +80,7 @@ async function convertResponse(
           totalRead += value.length;
           // Check if we've received a complete JSON-RPC response
           const text = decoder.decode(Buffer.concat(chunks.map((c) => Buffer.from(c))));
-          if (text.includes('"jsonrpc"') && text.includes('\n\n')) {
+          if (text.includes('"jsonrpc"') && text.includes("\n\n")) {
             break;
           }
         }
@@ -91,9 +89,7 @@ async function convertResponse(
 
     await readWithTimeout();
 
-    const body = Buffer.concat(chunks.map((c) => Buffer.from(c))).toString(
-      "utf-8"
-    );
+    const body = Buffer.concat(chunks.map((c) => Buffer.from(c))).toString("utf-8");
 
     return {
       status: response.status,
@@ -188,8 +184,7 @@ async function mcpHandler(
         jsonrpc: "2.0",
         error: {
           code: -32603,
-          message:
-            error instanceof Error ? error.message : "Internal server error",
+          message: error instanceof Error ? error.message : "Internal server error",
         },
         id: null,
       },

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -10,7 +10,7 @@ import { registerTools } from "./server.js";
 
 describe("server", () => {
   let server: Server;
-  let handlers: Map<unknown, Function>;
+  let handlers: Map<unknown, (...args: unknown[]) => unknown>;
 
   beforeEach(() => {
     handlers = new Map();
@@ -70,9 +70,9 @@ describe("server", () => {
     it("should throw error for unknown prompt", async () => {
       const handler = handlers.get(GetPromptRequestSchema);
 
-      await expect(
-        handler!({ params: { name: "unknown-prompt" } })
-      ).rejects.toThrow("Unknown prompt: unknown-prompt");
+      await expect(handler!({ params: { name: "unknown-prompt" } })).rejects.toThrow(
+        "Unknown prompt: unknown-prompt"
+      );
     });
   });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,8 +9,6 @@ import {
   ListToolsRequestSchema,
   ListPromptsRequestSchema,
   GetPromptRequestSchema,
-  ListResourcesRequestSchema,
-  ReadResourceRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { TOOL_DEFINITIONS } from "./tools/definitions.js";
 import { handleToolCall } from "./tools/handler.js";
@@ -771,11 +769,13 @@ export function registerTools(server: Server): void {
     prompts: [
       {
         name: "logic-apps-guide",
-        description: "System guidance for Azure Logic Apps operations - helps with tool selection and common workflows",
+        description:
+          "System guidance for Azure Logic Apps operations - helps with tool selection and common workflows",
       },
       {
         name: "native-operations-guide",
-        description: "Complete reference for all native Logic Apps operations (triggers, actions, control flow) with JSON schemas and examples. Use this when authoring or modifying workflow definitions.",
+        description:
+          "Complete reference for all native Logic Apps operations (triggers, actions, control flow) with JSON schemas and examples. Use this when authoring or modifying workflow definitions.",
       },
     ],
   }));

--- a/src/tools/definitions.test.ts
+++ b/src/tools/definitions.test.ts
@@ -64,9 +64,7 @@ describe("tool definitions", () => {
   });
 
   describe("get_workflow_definition", () => {
-    const tool = TOOL_DEFINITIONS.find(
-      (t) => t.name === "get_workflow_definition"
-    );
+    const tool = TOOL_DEFINITIONS.find((t) => t.name === "get_workflow_definition");
 
     it("should have optional workflowName parameter", () => {
       expect(tool?.inputSchema.properties?.workflowName).toBeDefined();

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -84,8 +84,7 @@ export const TOOL_DEFINITIONS: Tool[] = [
         },
         workflowName: {
           type: "string",
-          description:
-            "Workflow name (required for Standard SKU, omit for Consumption)",
+          description: "Workflow name (required for Standard SKU, omit for Consumption)",
         },
       },
       required: ["subscriptionId", "resourceGroupName", "logicAppName"],
@@ -120,7 +119,8 @@ export const TOOL_DEFINITIONS: Tool[] = [
   },
   {
     name: "list_run_history",
-    description: "Get the run history for a workflow with optional filtering. For Standard SKU, workflowName is required. Use search_runs for easier filtering by status/date. After finding a run, use get_run_details and get_run_actions to debug. Returns a nextLink if more pages are available - use skipToken to fetch the next page.",
+    description:
+      "Get the run history for a workflow with optional filtering. For Standard SKU, workflowName is required. Use search_runs for easier filtering by status/date. After finding a run, use get_run_details and get_run_actions to debug. Returns a nextLink if more pages are available - use skipToken to fetch the next page.",
     inputSchema: {
       type: "object",
       properties: {
@@ -150,7 +150,8 @@ export const TOOL_DEFINITIONS: Tool[] = [
         },
         skipToken: {
           type: "string",
-          description: "Pagination token from a previous response's nextLink to fetch the next page of results",
+          description:
+            "Pagination token from a previous response's nextLink to fetch the next page of results",
         },
       },
       required: ["subscriptionId", "resourceGroupName", "logicAppName"],
@@ -158,7 +159,8 @@ export const TOOL_DEFINITIONS: Tool[] = [
   },
   {
     name: "get_run_details",
-    description: "Get detailed information about a specific workflow run including status, timing, and error summary. For Standard SKU, workflowName is required. Use get_run_actions to see which specific action failed.",
+    description:
+      "Get detailed information about a specific workflow run including status, timing, and error summary. For Standard SKU, workflowName is required. Use get_run_actions to see which specific action failed.",
     inputSchema: {
       type: "object",
       properties: {
@@ -183,17 +185,13 @@ export const TOOL_DEFINITIONS: Tool[] = [
           description: "The run ID to retrieve",
         },
       },
-      required: [
-        "subscriptionId",
-        "resourceGroupName",
-        "logicAppName",
-        "runId",
-      ],
+      required: ["subscriptionId", "resourceGroupName", "logicAppName", "runId"],
     },
   },
   {
     name: "get_run_actions",
-    description: "Get the action execution details for a specific workflow run including status, timing, and trackedProperties. For Standard SKU, workflowName is required. Use get_action_io to see actual inputs/outputs for an action.",
+    description:
+      "Get the action execution details for a specific workflow run including status, timing, and trackedProperties. For Standard SKU, workflowName is required. Use get_action_io to see actual inputs/outputs for an action.",
     inputSchema: {
       type: "object",
       properties: {
@@ -227,7 +225,8 @@ export const TOOL_DEFINITIONS: Tool[] = [
   },
   {
     name: "get_connections",
-    description: "List API connections (e.g., Office 365, SQL, Service Bus) in a resource group. Connections are shared resources used by Logic Apps for authentication. Use get_connection_details or test_connection for more info.",
+    description:
+      "List API connections (e.g., Office 365, SQL, Service Bus) in a resource group. Connections are shared resources used by Logic Apps for authentication. Use get_connection_details or test_connection for more info.",
     inputSchema: {
       type: "object",
       properties: {
@@ -268,7 +267,8 @@ export const TOOL_DEFINITIONS: Tool[] = [
         },
         connectorName: {
           type: "string",
-          description: "Managed connector name (e.g., 'azureblob', 'sql', 'servicebus', 'office365')",
+          description:
+            "Managed connector name (e.g., 'azureblob', 'sql', 'servicebus', 'office365')",
         },
         location: {
           type: "string",
@@ -276,7 +276,8 @@ export const TOOL_DEFINITIONS: Tool[] = [
         },
         displayName: {
           type: "string",
-          description: "Friendly display name for the connection (optional, defaults to connectionName)",
+          description:
+            "Friendly display name for the connection (optional, defaults to connectionName)",
         },
         parameterValues: {
           type: "object",
@@ -285,12 +286,19 @@ export const TOOL_DEFINITIONS: Tool[] = [
           additionalProperties: true,
         },
       },
-      required: ["subscriptionId", "resourceGroupName", "connectionName", "connectorName", "location"],
+      required: [
+        "subscriptionId",
+        "resourceGroupName",
+        "connectionName",
+        "connectorName",
+        "location",
+      ],
     },
   },
   {
     name: "get_connector_swagger",
-    description: "Get the OpenAPI/Swagger definition for a managed connector (e.g., msnweather, sql, servicebus, office365). Returns available operations, paths, and schemas. ESSENTIAL for discovering correct action paths when creating or updating workflows with connector actions.",
+    description:
+      "Get the OpenAPI/Swagger definition for a managed connector (e.g., msnweather, sql, servicebus, office365). Returns available operations, paths, and schemas. ESSENTIAL for discovering correct action paths when creating or updating workflows with connector actions.",
     inputSchema: {
       type: "object",
       properties: {
@@ -304,7 +312,8 @@ export const TOOL_DEFINITIONS: Tool[] = [
         },
         connectorName: {
           type: "string",
-          description: "Connector name (e.g., 'msnweather', 'sql', 'servicebus', 'office365', 'azureblob')",
+          description:
+            "Connector name (e.g., 'msnweather', 'sql', 'servicebus', 'office365', 'azureblob')",
         },
       },
       required: ["subscriptionId", "location", "connectorName"],
@@ -347,11 +356,13 @@ export const TOOL_DEFINITIONS: Tool[] = [
         },
         operationId: {
           type: "string",
-          description: "The operationId from the connector swagger to invoke (e.g., 'GetTables', 'GetQueues', 'GetDataSets')",
+          description:
+            "The operationId from the connector swagger to invoke (e.g., 'GetTables', 'GetQueues', 'GetDataSets')",
         },
         parameters: {
           type: "object",
-          description: "Parameters required by the operation. Check the swagger for required parameters. For example, GetTable requires {table: 'tableName'}",
+          description:
+            "Parameters required by the operation. Check the swagger for required parameters. For example, GetTable requires {table: 'tableName'}",
           additionalProperties: true,
         },
       },
@@ -739,7 +750,8 @@ export const TOOL_DEFINITIONS: Tool[] = [
         },
         skipToken: {
           type: "string",
-          description: "Pagination token from a previous response's nextLink to fetch the next page of results",
+          description:
+            "Pagination token from a previous response's nextLink to fetch the next page of results",
         },
       },
       required: ["subscriptionId", "resourceGroupName", "logicAppName"],
@@ -896,7 +908,8 @@ export const TOOL_DEFINITIONS: Tool[] = [
         },
         triggerName: {
           type: "string",
-          description: "The name of the trigger to run (e.g., 'manual', 'When_a_HTTP_request_is_received')",
+          description:
+            "The name of the trigger to run (e.g., 'manual', 'When_a_HTTP_request_is_received')",
         },
         workflowName: {
           type: "string",
@@ -954,7 +967,8 @@ export const TOOL_DEFINITIONS: Tool[] = [
         },
         logicAppName: {
           type: "string",
-          description: "Logic App resource name (for Consumption, this becomes the new Logic App name)",
+          description:
+            "Logic App resource name (for Consumption, this becomes the new Logic App name)",
         },
         definition: {
           type: "object",
@@ -975,7 +989,8 @@ export const TOOL_DEFINITIONS: Tool[] = [
         },
         connections: {
           type: "object",
-          description: "API connection references for Consumption SKU. Object mapping connection names used in the definition to their connection details. Example: {\"office365\": {\"connectionName\": \"office365-test\", \"id\": \"/subscriptions/.../providers/Microsoft.Web/locations/.../managedApis/office365\"}}",
+          description:
+            'API connection references for Consumption SKU. Object mapping connection names used in the definition to their connection details. Example: {"office365": {"connectionName": "office365-test", "id": "/subscriptions/.../providers/Microsoft.Web/locations/.../managedApis/office365"}}',
           additionalProperties: {
             type: "object",
             properties: {
@@ -985,7 +1000,8 @@ export const TOOL_DEFINITIONS: Tool[] = [
               },
               id: {
                 type: "string",
-                description: "Resource ID of the managed API (e.g., /subscriptions/.../providers/Microsoft.Web/locations/.../managedApis/office365)",
+                description:
+                  "Resource ID of the managed API (e.g., /subscriptions/.../providers/Microsoft.Web/locations/.../managedApis/office365)",
               },
             },
             required: ["connectionName", "id"],
@@ -1029,7 +1045,8 @@ export const TOOL_DEFINITIONS: Tool[] = [
         },
         connections: {
           type: "object",
-          description: "API connection references for Consumption SKU. Object mapping connection names used in the definition to their connection details. Example: {\"office365\": {\"connectionName\": \"office365-test\", \"id\": \"/subscriptions/.../providers/Microsoft.Web/locations/.../managedApis/office365\"}}",
+          description:
+            'API connection references for Consumption SKU. Object mapping connection names used in the definition to their connection details. Example: {"office365": {"connectionName": "office365-test", "id": "/subscriptions/.../providers/Microsoft.Web/locations/.../managedApis/office365"}}',
           additionalProperties: {
             type: "object",
             properties: {
@@ -1039,7 +1056,8 @@ export const TOOL_DEFINITIONS: Tool[] = [
               },
               id: {
                 type: "string",
-                description: "Resource ID of the managed API (e.g., /subscriptions/.../providers/Microsoft.Web/locations/.../managedApis/office365)",
+                description:
+                  "Resource ID of the managed API (e.g., /subscriptions/.../providers/Microsoft.Web/locations/.../managedApis/office365)",
               },
             },
             required: ["connectionName", "id"],
@@ -1087,7 +1105,8 @@ export const TOOL_DEFINITIONS: Tool[] = [
         topic: {
           type: "string",
           enum: ["expression-errors", "connection-issues", "run-failures", "known-limitations"],
-          description: "The troubleshooting topic: 'expression-errors' for null checks, type conversions, date handling; 'connection-issues' for OAuth, Managed Identity, auth problems; 'run-failures' for action failures, triggers, loops, timeouts; 'known-limitations' for platform constraints and workarounds",
+          description:
+            "The troubleshooting topic: 'expression-errors' for null checks, type conversions, date handling; 'connection-issues' for OAuth, Managed Identity, auth problems; 'run-failures' for action failures, triggers, loops, timeouts; 'known-limitations' for platform constraints and workarounds",
         },
       },
       required: ["topic"],
@@ -1103,7 +1122,8 @@ export const TOOL_DEFINITIONS: Tool[] = [
         topic: {
           type: "string",
           enum: ["workflow-patterns", "connector-patterns", "deployment"],
-          description: "The authoring topic: 'workflow-patterns' for triggers, control flow, error handling; 'connector-patterns' for SQL, Service Bus, Blob, Office 365; 'deployment' for ARM, Terraform, CI/CD",
+          description:
+            "The authoring topic: 'workflow-patterns' for triggers, control flow, error handling; 'connector-patterns' for SQL, Service Bus, Blob, Office 365; 'deployment' for ARM, Terraform, CI/CD",
         },
       },
       required: ["topic"],
@@ -1119,7 +1139,8 @@ export const TOOL_DEFINITIONS: Tool[] = [
         topic: {
           type: "string",
           enum: ["tool-catalog", "sku-differences"],
-          description: "The reference topic: 'tool-catalog' for all 33 MCP tools with examples; 'sku-differences' for Consumption vs Standard deep dive",
+          description:
+            "The reference topic: 'tool-catalog' for all 33 MCP tools with examples; 'sku-differences' for Consumption vs Standard deep dive",
         },
       },
       required: ["topic"],
@@ -1134,8 +1155,15 @@ export const TOOL_DEFINITIONS: Tool[] = [
       properties: {
         topic: {
           type: "string",
-          enum: ["diagnose-failures", "explain-workflow", "monitor-workflows", "create-workflow", "fix-workflow"],
-          description: "The instruction topic: 'diagnose-failures' when user asks about failures or errors; 'explain-workflow' to understand what a workflow does; 'monitor-workflows' to check status and health; 'create-workflow' to build new workflows; 'fix-workflow' to modify and repair existing workflows",
+          enum: [
+            "diagnose-failures",
+            "explain-workflow",
+            "monitor-workflows",
+            "create-workflow",
+            "fix-workflow",
+          ],
+          description:
+            "The instruction topic: 'diagnose-failures' when user asks about failures or errors; 'explain-workflow' to understand what a workflow does; 'monitor-workflows' to check status and health; 'create-workflow' to build new workflows; 'fix-workflow' to modify and repair existing workflows",
         },
       },
       required: ["topic"],

--- a/src/tools/expressions.ts
+++ b/src/tools/expressions.ts
@@ -37,11 +37,7 @@ export async function getExpressionTraces(
   actionName: string,
   workflowName?: string
 ): Promise<GetExpressionTracesResult> {
-  const sku = await detectLogicAppSku(
-    subscriptionId,
-    resourceGroupName,
-    logicAppName
-  );
+  const sku = await detectLogicAppSku(subscriptionId, resourceGroupName, logicAppName);
 
   if (sku === "consumption") {
     return getExpressionTracesConsumption(
@@ -55,10 +51,7 @@ export async function getExpressionTraces(
 
   // Standard requires workflowName
   if (!workflowName) {
-    throw new McpError(
-      "InvalidParameter",
-      "workflowName is required for Standard Logic Apps"
-    );
+    throw new McpError("InvalidParameter", "workflowName is required for Standard Logic Apps");
   }
 
   return getExpressionTracesStandard(

--- a/src/tools/handler.test.ts
+++ b/src/tools/handler.test.ts
@@ -28,11 +28,7 @@ vi.mock("./connections.js", () => ({
 
 import { listSubscriptions } from "./subscriptions.js";
 import { listLogicApps } from "./logicApps.js";
-import {
-  listWorkflows,
-  getWorkflowDefinition,
-  getWorkflowTriggers,
-} from "./workflows.js";
+import { listWorkflows, getWorkflowDefinition, getWorkflowTriggers } from "./workflows.js";
 import { listRunHistory, getRunDetails, getRunActions } from "./runs.js";
 import { getConnections } from "./connections.js";
 
@@ -109,12 +105,7 @@ describe("handleToolCall", () => {
       logicAppName: "my-app",
     });
 
-    expect(getWorkflowTriggers).toHaveBeenCalledWith(
-      "sub-123",
-      "rg-test",
-      "my-app",
-      undefined
-    );
+    expect(getWorkflowTriggers).toHaveBeenCalledWith("sub-123", "rg-test", "my-app", undefined);
   });
 
   it("should call listRunHistory with optional parameters", async () => {

--- a/src/tools/handler.ts
+++ b/src/tools/handler.ts
@@ -19,14 +19,33 @@ import {
   deleteWorkflow,
 } from "./workflows.js";
 import { getTriggerHistory, getTriggerCallbackUrl, runTrigger } from "./triggers.js";
-import { listRunHistory, getRunDetails, getRunActions, getActionIO, searchRuns, cancelRun } from "./runs.js";
+import {
+  listRunHistory,
+  getRunDetails,
+  getRunActions,
+  getActionIO,
+  searchRuns,
+  cancelRun,
+} from "./runs.js";
 import { getActionRepetitions, getScopeRepetitions } from "./repetitions.js";
 import { getActionRequestHistory } from "./requestHistory.js";
 import { getExpressionTraces } from "./expressions.js";
 import { getWorkflowSwagger } from "./swagger.js";
-import { getConnections, getConnectionDetails, testConnection, getConnectorSwagger, invokeConnectorOperation, createConnection } from "./connections.js";
+import {
+  getConnections,
+  getConnectionDetails,
+  testConnection,
+  getConnectorSwagger,
+  invokeConnectorOperation,
+  createConnection,
+} from "./connections.js";
 import { getHostStatus } from "./host.js";
-import { getTroubleshootingGuide, getAuthoringGuide, getReference, getWorkflowInstructions } from "./knowledge.js";
+import {
+  getTroubleshootingGuide,
+  getAuthoringGuide,
+  getReference,
+  getWorkflowInstructions,
+} from "./knowledge.js";
 import { McpError, formatError } from "../utils/errors.js";
 
 export async function handleToolCall(
@@ -334,7 +353,11 @@ export async function handleToolCall(
       // Knowledge tools
       case "get_troubleshooting_guide":
         result = getTroubleshootingGuide(
-          args.topic as "expression-errors" | "connection-issues" | "run-failures" | "known-limitations"
+          args.topic as
+            | "expression-errors"
+            | "connection-issues"
+            | "run-failures"
+            | "known-limitations"
         );
         break;
       case "get_authoring_guide":
@@ -343,13 +366,16 @@ export async function handleToolCall(
         );
         break;
       case "get_reference":
-        result = getReference(
-          args.topic as "tool-catalog" | "sku-differences"
-        );
+        result = getReference(args.topic as "tool-catalog" | "sku-differences");
         break;
       case "get_workflow_instructions":
         result = getWorkflowInstructions(
-          args.topic as "diagnose-failures" | "explain-workflow" | "monitor-workflows" | "create-workflow" | "fix-workflow"
+          args.topic as
+            | "diagnose-failures"
+            | "explain-workflow"
+            | "monitor-workflows"
+            | "create-workflow"
+            | "fix-workflow"
         );
         break;
       default:

--- a/src/tools/host.ts
+++ b/src/tools/host.ts
@@ -31,11 +31,7 @@ export async function getHostStatus(
   resourceGroupName: string,
   logicAppName: string
 ): Promise<GetHostStatusResult> {
-  const sku = await detectLogicAppSku(
-    subscriptionId,
-    resourceGroupName,
-    logicAppName
-  );
+  const sku = await detectLogicAppSku(subscriptionId, resourceGroupName, logicAppName);
 
   if (sku === "consumption") {
     throw new McpError(
@@ -50,11 +46,7 @@ export async function getHostStatus(
     logicAppName
   );
 
-  const status = await workflowMgmtRequest<HostStatus>(
-    hostname,
-    `/admin/host/status`,
-    masterKey
-  );
+  const status = await workflowMgmtRequest<HostStatus>(hostname, `/admin/host/status`, masterKey);
 
   return {
     sku: "standard",

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -36,19 +36,17 @@ export type {
 } from "./runs.js";
 
 export { getConnections, getConnectionDetails, testConnection } from "./connections.js";
-export type { GetConnectionsResult, GetConnectionDetailsResult, TestConnectionResult } from "./connections.js";
+export type {
+  GetConnectionsResult,
+  GetConnectionDetailsResult,
+  TestConnectionResult,
+} from "./connections.js";
 
 export { getTriggerHistory, getTriggerCallbackUrl } from "./triggers.js";
-export type {
-  GetTriggerHistoryResult,
-  GetTriggerCallbackUrlResult,
-} from "./triggers.js";
+export type { GetTriggerHistoryResult, GetTriggerCallbackUrlResult } from "./triggers.js";
 
 export { getActionRepetitions, getScopeRepetitions } from "./repetitions.js";
-export type {
-  GetActionRepetitionsResult,
-  GetScopeRepetitionsResult,
-} from "./repetitions.js";
+export type { GetActionRepetitionsResult, GetScopeRepetitionsResult } from "./repetitions.js";
 
 export { getActionRequestHistory } from "./requestHistory.js";
 export type { GetActionRequestHistoryResult } from "./requestHistory.js";

--- a/src/tools/knowledge.ts
+++ b/src/tools/knowledge.ts
@@ -19,7 +19,7 @@ const KNOWLEDGE_ROOT = join(__dirname, "..", "..", "knowledge");
 /**
  * Valid topics for troubleshooting guides
  */
-export type TroubleshootingTopic = 
+export type TroubleshootingTopic =
   | "expression-errors"
   | "connection-issues"
   | "run-failures"
@@ -28,17 +28,12 @@ export type TroubleshootingTopic =
 /**
  * Valid topics for authoring guides
  */
-export type AuthoringTopic = 
-  | "workflow-patterns"
-  | "connector-patterns"
-  | "deployment";
+export type AuthoringTopic = "workflow-patterns" | "connector-patterns" | "deployment";
 
 /**
  * Valid topics for reference guides
  */
-export type ReferenceTopic = 
-  | "tool-catalog"
-  | "sku-differences";
+export type ReferenceTopic = "tool-catalog" | "sku-differences";
 
 /**
  * Valid workflow instruction topics
@@ -55,34 +50,39 @@ export type WorkflowInstructionTopic =
  */
 function readKnowledgeFile(relativePath: string): string {
   const fullPath = join(KNOWLEDGE_ROOT, relativePath);
-  
+
   if (!existsSync(fullPath)) {
     throw new Error(`Documentation file not found: ${relativePath}. Looking in: ${fullPath}`);
   }
-  
+
   return readFileSync(fullPath, "utf-8");
 }
 
 /**
  * Get troubleshooting guidance for Logic Apps issues.
- * 
+ *
  * @param topic - The troubleshooting topic to retrieve
  * @returns The markdown content of the troubleshooting guide
  */
-export function getTroubleshootingGuide(topic: TroubleshootingTopic): { topic: string; content: string } {
+export function getTroubleshootingGuide(topic: TroubleshootingTopic): {
+  topic: string;
+  content: string;
+} {
   const validTopics: TroubleshootingTopic[] = [
     "expression-errors",
-    "connection-issues", 
+    "connection-issues",
     "run-failures",
     "known-limitations",
   ];
-  
+
   if (!validTopics.includes(topic)) {
-    throw new Error(`Invalid troubleshooting topic: ${topic}. Valid topics: ${validTopics.join(", ")}`);
+    throw new Error(
+      `Invalid troubleshooting topic: ${topic}. Valid topics: ${validTopics.join(", ")}`
+    );
   }
-  
+
   const content = readKnowledgeFile(join("troubleshooting", `${topic}.md`));
-  
+
   return {
     topic,
     content,
@@ -91,23 +91,19 @@ export function getTroubleshootingGuide(topic: TroubleshootingTopic): { topic: s
 
 /**
  * Get authoring guidance for creating Logic Apps workflows.
- * 
+ *
  * @param topic - The authoring topic to retrieve
  * @returns The markdown content of the authoring guide
  */
 export function getAuthoringGuide(topic: AuthoringTopic): { topic: string; content: string } {
-  const validTopics: AuthoringTopic[] = [
-    "workflow-patterns",
-    "connector-patterns",
-    "deployment",
-  ];
-  
+  const validTopics: AuthoringTopic[] = ["workflow-patterns", "connector-patterns", "deployment"];
+
   if (!validTopics.includes(topic)) {
     throw new Error(`Invalid authoring topic: ${topic}. Valid topics: ${validTopics.join(", ")}`);
   }
-  
+
   const content = readKnowledgeFile(join("authoring", `${topic}.md`));
-  
+
   return {
     topic,
     content,
@@ -116,22 +112,19 @@ export function getAuthoringGuide(topic: AuthoringTopic): { topic: string; conte
 
 /**
  * Get reference documentation for Logic Apps.
- * 
+ *
  * @param topic - The reference topic to retrieve
  * @returns The markdown content of the reference guide
  */
 export function getReference(topic: ReferenceTopic): { topic: string; content: string } {
-  const validTopics: ReferenceTopic[] = [
-    "tool-catalog",
-    "sku-differences",
-  ];
-  
+  const validTopics: ReferenceTopic[] = ["tool-catalog", "sku-differences"];
+
   if (!validTopics.includes(topic)) {
     throw new Error(`Invalid reference topic: ${topic}. Valid topics: ${validTopics.join(", ")}`);
   }
-  
+
   const content = readKnowledgeFile(join("reference", `${topic}.md`));
-  
+
   return {
     topic,
     content,
@@ -140,11 +133,14 @@ export function getReference(topic: ReferenceTopic): { topic: string; content: s
 
 /**
  * Get step-by-step workflow instructions for common user tasks.
- * 
+ *
  * @param topic - The workflow instruction topic to retrieve
  * @returns The markdown content with detailed steps
  */
-export function getWorkflowInstructions(topic: WorkflowInstructionTopic): { topic: string; content: string } {
+export function getWorkflowInstructions(topic: WorkflowInstructionTopic): {
+  topic: string;
+  content: string;
+} {
   const validTopics: WorkflowInstructionTopic[] = [
     "diagnose-failures",
     "explain-workflow",
@@ -152,13 +148,15 @@ export function getWorkflowInstructions(topic: WorkflowInstructionTopic): { topi
     "create-workflow",
     "fix-workflow",
   ];
-  
+
   if (!validTopics.includes(topic)) {
-    throw new Error(`Invalid workflow instruction topic: ${topic}. Valid topics: ${validTopics.join(", ")}`);
+    throw new Error(
+      `Invalid workflow instruction topic: ${topic}. Valid topics: ${validTopics.join(", ")}`
+    );
   }
-  
+
   const content = readKnowledgeFile(join("workflows", `${topic}.md`));
-  
+
   return {
     topic,
     content,

--- a/src/tools/logicApps.ts
+++ b/src/tools/logicApps.ts
@@ -3,11 +3,7 @@
  */
 
 import { armRequestAllPages } from "../utils/http.js";
-import {
-  ConsumptionLogicApp,
-  StandardLogicApp,
-  LogicApp,
-} from "../types/logicApp.js";
+import { ConsumptionLogicApp, StandardLogicApp, LogicApp } from "../types/logicApp.js";
 import { extractResourceGroup } from "./shared.js";
 
 export interface ListLogicAppsResult {
@@ -23,19 +19,13 @@ export async function listLogicApps(
 
   // Fetch Consumption Logic Apps
   if (sku === "consumption" || sku === "all") {
-    const consumptionApps = await fetchConsumptionLogicApps(
-      subscriptionId,
-      resourceGroupName
-    );
+    const consumptionApps = await fetchConsumptionLogicApps(subscriptionId, resourceGroupName);
     logicApps.push(...consumptionApps);
   }
 
   // Fetch Standard Logic Apps
   if (sku === "standard" || sku === "all") {
-    const standardApps = await fetchStandardLogicApps(
-      subscriptionId,
-      resourceGroupName
-    );
+    const standardApps = await fetchStandardLogicApps(subscriptionId, resourceGroupName);
     logicApps.push(...standardApps);
   }
 
@@ -80,9 +70,7 @@ async function fetchStandardLogicApps(
   });
 
   // Filter to only workflow apps
-  const workflowApps = sites.filter((site) =>
-    site.kind?.toLowerCase().includes("workflowapp")
-  );
+  const workflowApps = sites.filter((site) => site.kind?.toLowerCase().includes("workflowapp"));
 
   return workflowApps.map((app) => ({
     id: app.id,

--- a/src/tools/repetitions.ts
+++ b/src/tools/repetitions.ts
@@ -2,11 +2,7 @@
  * Action and scope repetition tools for debugging loops and conditional branches.
  */
 
-import {
-  armRequest,
-  armRequestAllPages,
-  workflowMgmtRequest,
-} from "../utils/http.js";
+import { armRequest, armRequestAllPages, workflowMgmtRequest } from "../utils/http.js";
 import { McpError } from "../utils/errors.js";
 import { detectLogicAppSku, getStandardAppAccess } from "./shared.js";
 
@@ -92,11 +88,7 @@ export async function getActionRepetitions(
   workflowName?: string,
   repetitionName?: string
 ): Promise<GetActionRepetitionsResult> {
-  const sku = await detectLogicAppSku(
-    subscriptionId,
-    resourceGroupName,
-    logicAppName
-  );
+  const sku = await detectLogicAppSku(subscriptionId, resourceGroupName, logicAppName);
 
   if (sku === "consumption") {
     return getActionRepetitionsConsumption(
@@ -111,10 +103,7 @@ export async function getActionRepetitions(
 
   // Standard requires workflowName
   if (!workflowName) {
-    throw new McpError(
-      "InvalidParameter",
-      "workflowName is required for Standard Logic Apps"
-    );
+    throw new McpError("InvalidParameter", "workflowName is required for Standard Logic Apps");
   }
 
   return getActionRepetitionsStandard(
@@ -139,10 +128,9 @@ async function getActionRepetitionsConsumption(
   const basePath = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.Logic/workflows/${logicAppName}/runs/${runId}/actions/${actionName}/repetitions`;
 
   if (repetitionName) {
-    const repetition = await armRequest<ActionRepetitionEntry>(
-      `${basePath}/${repetitionName}`,
-      { queryParams: { "api-version": "2019-05-01" } }
-    );
+    const repetition = await armRequest<ActionRepetitionEntry>(`${basePath}/${repetitionName}`, {
+      queryParams: { "api-version": "2019-05-01" },
+    });
 
     return {
       actionName,
@@ -162,10 +150,9 @@ async function getActionRepetitionsConsumption(
     };
   }
 
-  const repetitions = await armRequestAllPages<ActionRepetitionEntry>(
-    basePath,
-    { "api-version": "2019-05-01" }
-  );
+  const repetitions = await armRequestAllPages<ActionRepetitionEntry>(basePath, {
+    "api-version": "2019-05-01",
+  });
 
   return {
     actionName,
@@ -259,11 +246,7 @@ export async function getScopeRepetitions(
   actionName: string,
   workflowName?: string
 ): Promise<GetScopeRepetitionsResult> {
-  const sku = await detectLogicAppSku(
-    subscriptionId,
-    resourceGroupName,
-    logicAppName
-  );
+  const sku = await detectLogicAppSku(subscriptionId, resourceGroupName, logicAppName);
 
   if (sku === "consumption") {
     return getScopeRepetitionsConsumption(
@@ -277,10 +260,7 @@ export async function getScopeRepetitions(
 
   // Standard requires workflowName
   if (!workflowName) {
-    throw new McpError(
-      "InvalidParameter",
-      "workflowName is required for Standard Logic Apps"
-    );
+    throw new McpError("InvalidParameter", "workflowName is required for Standard Logic Apps");
   }
 
   return getScopeRepetitionsStandard(

--- a/src/tools/requestHistory.ts
+++ b/src/tools/requestHistory.ts
@@ -2,11 +2,7 @@
  * Action request history tools for debugging HTTP connector calls.
  */
 
-import {
-  armRequest,
-  armRequestAllPages,
-  workflowMgmtRequest,
-} from "../utils/http.js";
+import { armRequest, armRequestAllPages, workflowMgmtRequest } from "../utils/http.js";
 import { McpError } from "../utils/errors.js";
 import { detectLogicAppSku, getStandardAppAccess } from "./shared.js";
 
@@ -75,11 +71,7 @@ export async function getActionRequestHistory(
   workflowName?: string,
   requestHistoryName?: string
 ): Promise<GetActionRequestHistoryResult> {
-  const sku = await detectLogicAppSku(
-    subscriptionId,
-    resourceGroupName,
-    logicAppName
-  );
+  const sku = await detectLogicAppSku(subscriptionId, resourceGroupName, logicAppName);
 
   if (sku === "consumption") {
     return getRequestHistoryConsumption(
@@ -94,10 +86,7 @@ export async function getActionRequestHistory(
 
   // Standard requires workflowName
   if (!workflowName) {
-    throw new McpError(
-      "InvalidParameter",
-      "workflowName is required for Standard Logic Apps"
-    );
+    throw new McpError("InvalidParameter", "workflowName is required for Standard Logic Apps");
   }
 
   return getRequestHistoryStandard(
@@ -122,10 +111,9 @@ async function getRequestHistoryConsumption(
   const basePath = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.Logic/workflows/${logicAppName}/runs/${runId}/actions/${actionName}/requestHistories`;
 
   if (requestHistoryName) {
-    const entry = await armRequest<RequestHistoryEntry>(
-      `${basePath}/${requestHistoryName}`,
-      { queryParams: { "api-version": "2019-05-01" } }
-    );
+    const entry = await armRequest<RequestHistoryEntry>(`${basePath}/${requestHistoryName}`, {
+      queryParams: { "api-version": "2019-05-01" },
+    });
 
     return {
       actionName,

--- a/src/tools/subscriptions.ts
+++ b/src/tools/subscriptions.ts
@@ -20,10 +20,9 @@ export interface SubscriptionResult {
 }
 
 export async function listSubscriptions(): Promise<SubscriptionResult> {
-  const subscriptions = await armRequestAllPages<SubscriptionResponse>(
-    "/subscriptions",
-    { "api-version": "2022-12-01" }
-  );
+  const subscriptions = await armRequestAllPages<SubscriptionResponse>("/subscriptions", {
+    "api-version": "2022-12-01",
+  });
 
   return {
     subscriptions: subscriptions.map((sub) => ({

--- a/src/tools/swagger.ts
+++ b/src/tools/swagger.ts
@@ -32,34 +32,18 @@ export async function getWorkflowSwagger(
   logicAppName: string,
   workflowName?: string
 ): Promise<GetWorkflowSwaggerResult> {
-  const sku = await detectLogicAppSku(
-    subscriptionId,
-    resourceGroupName,
-    logicAppName
-  );
+  const sku = await detectLogicAppSku(subscriptionId, resourceGroupName, logicAppName);
 
   if (sku === "consumption") {
-    return getSwaggerConsumption(
-      subscriptionId,
-      resourceGroupName,
-      logicAppName
-    );
+    return getSwaggerConsumption(subscriptionId, resourceGroupName, logicAppName);
   }
 
   // Standard requires workflowName
   if (!workflowName) {
-    throw new McpError(
-      "InvalidParameter",
-      "workflowName is required for Standard Logic Apps"
-    );
+    throw new McpError("InvalidParameter", "workflowName is required for Standard Logic Apps");
   }
 
-  return getSwaggerStandard(
-    subscriptionId,
-    resourceGroupName,
-    logicAppName,
-    workflowName
-  );
+  return getSwaggerStandard(subscriptionId, resourceGroupName, logicAppName, workflowName);
 }
 
 async function getSwaggerConsumption(

--- a/src/tools/triggers.ts
+++ b/src/tools/triggers.ts
@@ -2,11 +2,7 @@
  * Trigger-related tools for Logic Apps.
  */
 
-import {
-  armRequest,
-  armRequestAllPages,
-  workflowMgmtRequest,
-} from "../utils/http.js";
+import { armRequest, armRequestAllPages, workflowMgmtRequest } from "../utils/http.js";
 import { McpError } from "../utils/errors.js";
 import { detectLogicAppSku, getStandardAppAccess } from "./shared.js";
 
@@ -63,11 +59,7 @@ export async function getTriggerHistory(
   top?: number,
   filter?: string
 ): Promise<GetTriggerHistoryResult> {
-  const sku = await detectLogicAppSku(
-    subscriptionId,
-    resourceGroupName,
-    logicAppName
-  );
+  const sku = await detectLogicAppSku(subscriptionId, resourceGroupName, logicAppName);
 
   const effectiveTop = Math.min(top ?? 25, 100);
 
@@ -84,10 +76,7 @@ export async function getTriggerHistory(
 
   // Standard requires workflowName
   if (!workflowName) {
-    throw new McpError(
-      "InvalidParameter",
-      "workflowName is required for Standard Logic Apps"
-    );
+    throw new McpError("InvalidParameter", "workflowName is required for Standard Logic Apps");
   }
 
   return getTriggerHistoryStandard(
@@ -208,27 +197,15 @@ export async function getTriggerCallbackUrl(
   triggerName: string,
   workflowName?: string
 ): Promise<GetTriggerCallbackUrlResult> {
-  const sku = await detectLogicAppSku(
-    subscriptionId,
-    resourceGroupName,
-    logicAppName
-  );
+  const sku = await detectLogicAppSku(subscriptionId, resourceGroupName, logicAppName);
 
   if (sku === "consumption") {
-    return getCallbackUrlConsumption(
-      subscriptionId,
-      resourceGroupName,
-      logicAppName,
-      triggerName
-    );
+    return getCallbackUrlConsumption(subscriptionId, resourceGroupName, logicAppName, triggerName);
   }
 
   // Standard requires workflowName
   if (!workflowName) {
-    throw new McpError(
-      "InvalidParameter",
-      "workflowName is required for Standard Logic Apps"
-    );
+    throw new McpError("InvalidParameter", "workflowName is required for Standard Logic Apps");
   }
 
   return getCallbackUrlStandard(
@@ -303,11 +280,7 @@ export async function runTrigger(
   triggerName: string,
   workflowName?: string
 ): Promise<RunTriggerResult> {
-  const sku = await detectLogicAppSku(
-    subscriptionId,
-    resourceGroupName,
-    logicAppName
-  );
+  const sku = await detectLogicAppSku(subscriptionId, resourceGroupName, logicAppName);
 
   if (sku === "consumption") {
     await armRequest(
@@ -324,10 +297,7 @@ export async function runTrigger(
 
   // Standard requires workflowName
   if (!workflowName) {
-    throw new McpError(
-      "InvalidParameter",
-      "workflowName is required for Standard Logic Apps"
-    );
+    throw new McpError("InvalidParameter", "workflowName is required for Standard Logic Apps");
   }
 
   // For Standard, use the ARM API with hostruntime path

--- a/src/tools/workflows.ts
+++ b/src/tools/workflows.ts
@@ -2,17 +2,11 @@
  * Workflow operations for both SKUs.
  */
 
-import {
-  armRequest,
-  armRequestAllPages,
-  vfsRequest,
-  workflowMgmtRequest,
-} from "../utils/http.js";
+import { armRequest, armRequestAllPages, vfsRequest, workflowMgmtRequest } from "../utils/http.js";
 import {
   ConsumptionLogicApp,
   StandardWorkflow,
   StandardWorkflowDefinitionFile,
-  StandardWorkflowUpdatePayload,
   TriggerState,
   WorkflowDefinition,
   WorkflowVersion,
@@ -63,11 +57,7 @@ export async function listWorkflows(
   resourceGroupName: string,
   logicAppName: string
 ): Promise<ListWorkflowsResult> {
-  const sku = await detectLogicAppSku(
-    subscriptionId,
-    resourceGroupName,
-    logicAppName
-  );
+  const sku = await detectLogicAppSku(subscriptionId, resourceGroupName, logicAppName);
 
   if (sku === "consumption") {
     const workflow = await armRequest<ConsumptionLogicApp>(
@@ -117,11 +107,7 @@ export async function getWorkflowDefinition(
   logicAppName: string,
   workflowName?: string
 ): Promise<GetWorkflowDefinitionResult> {
-  const sku = await detectLogicAppSku(
-    subscriptionId,
-    resourceGroupName,
-    logicAppName
-  );
+  const sku = await detectLogicAppSku(subscriptionId, resourceGroupName, logicAppName);
 
   if (sku === "consumption") {
     const workflow = await armRequest<ConsumptionLogicApp>(
@@ -137,10 +123,7 @@ export async function getWorkflowDefinition(
 
   // Standard - get definition from VFS endpoint
   if (!workflowName) {
-    throw new McpError(
-      "InvalidParameter",
-      "workflowName is required for Standard Logic Apps"
-    );
+    throw new McpError("InvalidParameter", "workflowName is required for Standard Logic Apps");
   }
 
   const { hostname, masterKey } = await getStandardAppAccess(
@@ -148,7 +131,7 @@ export async function getWorkflowDefinition(
     resourceGroupName,
     logicAppName
   );
-  
+
   // The workflow definition is stored in the VFS at /admin/vfs/site/wwwroot/{workflowName}/workflow.json
   const definitionFile = await workflowMgmtRequest<StandardWorkflowDefinitionFile>(
     hostname,
@@ -170,11 +153,7 @@ export async function getWorkflowTriggers(
   logicAppName: string,
   workflowName?: string
 ): Promise<GetWorkflowTriggersResult> {
-  const sku = await detectLogicAppSku(
-    subscriptionId,
-    resourceGroupName,
-    logicAppName
-  );
+  const sku = await detectLogicAppSku(subscriptionId, resourceGroupName, logicAppName);
 
   if (sku === "consumption") {
     const triggers = await armRequestAllPages<TriggerState>(
@@ -195,10 +174,7 @@ export async function getWorkflowTriggers(
 
   // Standard - get triggers from workflow metadata (available in list/get workflow response)
   if (!workflowName) {
-    throw new McpError(
-      "InvalidParameter",
-      "workflowName is required for Standard Logic Apps"
-    );
+    throw new McpError("InvalidParameter", "workflowName is required for Standard Logic Apps");
   }
 
   const { hostname, masterKey } = await getStandardAppAccess(
@@ -206,7 +182,7 @@ export async function getWorkflowTriggers(
     resourceGroupName,
     logicAppName
   );
-  
+
   const workflow = await workflowMgmtRequest<StandardWorkflow>(
     hostname,
     `/runtime/webhooks/workflow/api/management/workflows/${workflowName}?api-version=2020-05-01-preview`,
@@ -214,13 +190,11 @@ export async function getWorkflowTriggers(
   );
 
   return {
-    triggers: Object.entries(workflow.triggers ?? {}).map(
-      ([name, trigger]) => ({
-        name,
-        type: trigger.type,
-        state: workflow.isDisabled ? "Disabled" : "Enabled",
-      })
-    ),
+    triggers: Object.entries(workflow.triggers ?? {}).map(([name, trigger]) => ({
+      name,
+      type: trigger.type,
+      state: workflow.isDisabled ? "Disabled" : "Enabled",
+    })),
   };
 }
 
@@ -234,11 +208,7 @@ export async function listWorkflowVersions(
   logicAppName: string,
   top?: number
 ): Promise<ListWorkflowVersionsResult> {
-  const sku = await detectLogicAppSku(
-    subscriptionId,
-    resourceGroupName,
-    logicAppName
-  );
+  const sku = await detectLogicAppSku(subscriptionId, resourceGroupName, logicAppName);
 
   if (sku !== "consumption") {
     throw new McpError(
@@ -285,11 +255,7 @@ export async function getWorkflowVersion(
   logicAppName: string,
   versionId: string
 ): Promise<GetWorkflowVersionResult> {
-  const sku = await detectLogicAppSku(
-    subscriptionId,
-    resourceGroupName,
-    logicAppName
-  );
+  const sku = await detectLogicAppSku(subscriptionId, resourceGroupName, logicAppName);
 
   if (sku !== "consumption") {
     throw new McpError(
@@ -382,11 +348,7 @@ export async function enableWorkflow(
   logicAppName: string,
   workflowName?: string
 ): Promise<EnableDisableWorkflowResult> {
-  const sku = await detectLogicAppSku(
-    subscriptionId,
-    resourceGroupName,
-    logicAppName
-  );
+  const sku = await detectLogicAppSku(subscriptionId, resourceGroupName, logicAppName);
 
   if (sku === "consumption") {
     await armRequest(
@@ -404,10 +366,7 @@ export async function enableWorkflow(
 
   // Standard - requires workflowName
   if (!workflowName) {
-    throw new McpError(
-      "InvalidParameter",
-      "workflowName is required for Standard Logic Apps"
-    );
+    throw new McpError("InvalidParameter", "workflowName is required for Standard Logic Apps");
   }
 
   // Standard Logic Apps use app settings to control workflow state
@@ -437,11 +396,7 @@ export async function disableWorkflow(
   logicAppName: string,
   workflowName?: string
 ): Promise<EnableDisableWorkflowResult> {
-  const sku = await detectLogicAppSku(
-    subscriptionId,
-    resourceGroupName,
-    logicAppName
-  );
+  const sku = await detectLogicAppSku(subscriptionId, resourceGroupName, logicAppName);
 
   if (sku === "consumption") {
     await armRequest(
@@ -459,10 +414,7 @@ export async function disableWorkflow(
 
   // Standard - requires workflowName
   if (!workflowName) {
-    throw new McpError(
-      "InvalidParameter",
-      "workflowName is required for Standard Logic Apps"
-    );
+    throw new McpError("InvalidParameter", "workflowName is required for Standard Logic Apps");
   }
 
   // Standard Logic Apps use app settings to control workflow state
@@ -525,7 +477,10 @@ export async function createWorkflow(
     // Build parameters with connection references if provided
     let parameters: Record<string, unknown> | undefined;
     if (connections && Object.keys(connections).length > 0) {
-      const connectionsValue: Record<string, { connectionId: string; connectionName: string; id: string }> = {};
+      const connectionsValue: Record<
+        string,
+        { connectionId: string; connectionName: string; id: string }
+      > = {};
       for (const [name, ref] of Object.entries(connections)) {
         connectionsValue[name] = {
           connectionId: `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.Web/connections/${ref.connectionName}`,
@@ -559,7 +514,7 @@ export async function createWorkflow(
     );
 
     const connectionCount = connections ? Object.keys(connections).length : 0;
-    const connectionMsg = connectionCount > 0 ? ` with ${connectionCount} API connection(s)` : '';
+    const connectionMsg = connectionCount > 0 ? ` with ${connectionCount} API connection(s)` : "";
     return {
       success: true,
       name: logicAppName,
@@ -580,15 +535,10 @@ export async function createWorkflow(
   };
 
   // Use VFS API to create the workflow.json file
-  await vfsRequest(
-    hostname,
-    `/admin/vfs/site/wwwroot/${workflowName}/workflow.json`,
-    masterKey,
-    {
-      method: "PUT",
-      body: workflowContent,
-    }
-  );
+  await vfsRequest(hostname, `/admin/vfs/site/wwwroot/${workflowName}/workflow.json`, masterKey, {
+    method: "PUT",
+    body: workflowContent,
+  });
 
   return {
     success: true,
@@ -625,11 +575,7 @@ export async function updateWorkflow(
   kind?: string,
   connections?: Record<string, ConnectionReference>
 ): Promise<UpdateWorkflowResult> {
-  const sku = await detectLogicAppSku(
-    subscriptionId,
-    resourceGroupName,
-    logicAppName
-  );
+  const sku = await detectLogicAppSku(subscriptionId, resourceGroupName, logicAppName);
 
   if (sku === "consumption") {
     // Get current workflow to preserve other properties
@@ -640,10 +586,10 @@ export async function updateWorkflow(
 
     // Get parameters declared in the definition
     const definitionParams = definition.parameters || {};
-    
+
     // Build parameters - only include parameters that are declared in the definition
-    let parameters: Record<string, unknown> = {};
-    
+    const parameters: Record<string, unknown> = {};
+
     // Copy over existing parameter values that are still in the definition
     if (current.properties.parameters) {
       for (const [key, value] of Object.entries(current.properties.parameters)) {
@@ -652,11 +598,14 @@ export async function updateWorkflow(
         }
       }
     }
-    
+
     // If connections are provided, build the $connections parameter
     if (connections && Object.keys(connections).length > 0) {
       // Build $connections parameter value
-      const connectionsValue: Record<string, { connectionId: string; connectionName: string; id: string }> = {};
+      const connectionsValue: Record<
+        string,
+        { connectionId: string; connectionName: string; id: string }
+      > = {};
       for (const [name, ref] of Object.entries(connections)) {
         connectionsValue[name] = {
           connectionId: `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.Web/connections/${ref.connectionName}`,
@@ -689,7 +638,7 @@ export async function updateWorkflow(
     );
 
     const connectionCount = connections ? Object.keys(connections).length : 0;
-    const connectionMsg = connectionCount > 0 ? ` with ${connectionCount} API connection(s)` : '';
+    const connectionMsg = connectionCount > 0 ? ` with ${connectionCount} API connection(s)` : "";
     return {
       success: true,
       name: logicAppName,
@@ -699,10 +648,7 @@ export async function updateWorkflow(
 
   // Standard - requires workflowName
   if (!workflowName) {
-    throw new McpError(
-      "InvalidParameter",
-      "workflowName is required for Standard Logic Apps"
-    );
+    throw new McpError("InvalidParameter", "workflowName is required for Standard Logic Apps");
   }
 
   // Standard: Update workflow using VFS API
@@ -718,15 +664,10 @@ export async function updateWorkflow(
   };
 
   // Use VFS API to update the workflow.json file
-  await vfsRequest(
-    hostname,
-    `/admin/vfs/site/wwwroot/${workflowName}/workflow.json`,
-    masterKey,
-    {
-      method: "PUT",
-      body: workflowContent,
-    }
-  );
+  await vfsRequest(hostname, `/admin/vfs/site/wwwroot/${workflowName}/workflow.json`, masterKey, {
+    method: "PUT",
+    body: workflowContent,
+  });
 
   return {
     success: true,
@@ -752,11 +693,7 @@ export async function deleteWorkflow(
   logicAppName: string,
   workflowName?: string
 ): Promise<DeleteWorkflowResult> {
-  const sku = await detectLogicAppSku(
-    subscriptionId,
-    resourceGroupName,
-    logicAppName
-  );
+  const sku = await detectLogicAppSku(subscriptionId, resourceGroupName, logicAppName);
 
   if (sku === "consumption") {
     await armRequest(
@@ -790,14 +727,9 @@ export async function deleteWorkflow(
   );
 
   // Delete the workflow folder (recursive)
-  await vfsRequest(
-    hostname,
-    `/admin/vfs/site/wwwroot/${workflowName}/?recursive=true`,
-    masterKey,
-    {
-      method: "DELETE",
-    }
-  );
+  await vfsRequest(hostname, `/admin/vfs/site/wwwroot/${workflowName}/?recursive=true`, masterKey, {
+    method: "DELETE",
+  });
 
   return {
     success: true,

--- a/src/types/logicApp.ts
+++ b/src/types/logicApp.ts
@@ -79,13 +79,7 @@ export interface WorkflowRun {
   name: string;
   type: string;
   properties: {
-    status:
-      | "Running"
-      | "Waiting"
-      | "Succeeded"
-      | "Failed"
-      | "Cancelled"
-      | "Skipped";
+    status: "Running" | "Waiting" | "Succeeded" | "Failed" | "Cancelled" | "Skipped";
     startTime: string;
     endTime?: string;
     trigger?: {

--- a/src/utils/errors.test.ts
+++ b/src/utils/errors.test.ts
@@ -42,11 +42,7 @@ describe("errors", () => {
 
     it("should format McpError with details", () => {
       const details = { resourceId: "/subscriptions/123" };
-      const error = new McpError(
-        "ResourceNotFound",
-        "Not found",
-        details
-      );
+      const error = new McpError("ResourceNotFound", "Not found", details);
       const formatted = formatError(error);
 
       expect(formatted.error.details).toEqual(details);

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -48,7 +48,7 @@ export async function armRequest<T>(
   if (!text) {
     return undefined as T;
   }
-  
+
   return JSON.parse(text) as T;
 }
 
@@ -144,9 +144,7 @@ export async function vfsRequest(
       "x-functions-key": masterKey,
       "Content-Type": "application/json",
       // VFS API requires If-Match header for PUT/DELETE operations
-      ...(options.method === "PUT" || options.method === "DELETE"
-        ? { "If-Match": "*" }
-        : {}),
+      ...(options.method === "PUT" || options.method === "DELETE" ? { "If-Match": "*" } : {}),
     },
     body: options.body ? JSON.stringify(options.body) : undefined,
   });


### PR DESCRIPTION
## Summary
- Add ESLint with TypeScript support using flat config format
- Add Prettier for consistent code formatting
- Add npm scripts: `lint`, `lint:fix`, `format`, `format:check`
- Fix 6 lint errors:
  - Remove unused imports in `server.ts`, `connections.ts`, `workflows.ts`
  - Change `let` to `const` in `workflows.ts`
  - Fix unsafe `Function` type in `server.test.ts`
- Format all source files with Prettier

## New Files
- `eslint.config.js` - ESLint flat config with TypeScript support
- `.prettierrc` - Prettier configuration
- `.prettierignore` - Files to exclude from formatting

## Test plan
- [x] `npm run lint` passes
- [x] `npm run format:check` passes  
- [x] All 104 tests pass