### PR TITLE
fix: Improve armRequest type safety for empty responses

### DIFF
--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -33,7 +33,9 @@ describe("server", () => {
 
     it("should list logic-apps-guide prompt", async () => {
       const handler = handlers.get(ListPromptsRequestSchema);
-      const result = await handler!();
+      const result = (await handler!()) as {
+        prompts: Array<{ name: string; description: string }>;
+      };
 
       expect(result.prompts).toHaveLength(2);
       expect(result.prompts[0].name).toBe("logic-apps-guide");
@@ -44,7 +46,9 @@ describe("server", () => {
 
     it("should return logic-apps-guide content", async () => {
       const handler = handlers.get(GetPromptRequestSchema);
-      const result = await handler!({ params: { name: "logic-apps-guide" } });
+      const result = (await handler!({ params: { name: "logic-apps-guide" } })) as {
+        messages: Array<{ role: string; content: { type: string; text: string } }>;
+      };
 
       expect(result.messages).toHaveLength(1);
       expect(result.messages[0].role).toBe("user");
@@ -56,7 +60,9 @@ describe("server", () => {
 
     it("should return native-operations-guide content", async () => {
       const handler = handlers.get(GetPromptRequestSchema);
-      const result = await handler!({ params: { name: "native-operations-guide" } });
+      const result = (await handler!({ params: { name: "native-operations-guide" } })) as {
+        messages: Array<{ role: string; content: { type: string; text: string } }>;
+      };
 
       expect(result.messages).toHaveLength(1);
       expect(result.messages[0].role).toBe("user");
@@ -87,7 +93,9 @@ describe("server", () => {
 
     it("should list all tools", async () => {
       const handler = handlers.get(ListToolsRequestSchema);
-      const result = await handler!();
+      const result = (await handler!()) as {
+        tools: Array<{ name: string; description: string; inputSchema: unknown }>;
+      };
 
       expect(result.tools.length).toBeGreaterThan(0);
       expect(result.tools[0]).toHaveProperty("name");

--- a/src/tools/runs.ts
+++ b/src/tools/runs.ts
@@ -2,7 +2,12 @@
  * Workflow run history operations for both SKUs.
  */
 
-import { armRequest, armRequestAllPages, workflowMgmtRequest } from "../utils/http.js";
+import {
+  armRequest,
+  armRequestVoid,
+  armRequestAllPages,
+  workflowMgmtRequest,
+} from "../utils/http.js";
 import { WorkflowRun, RunAction, ConsumptionLogicApp } from "../types/logicApp.js";
 import { McpError } from "../utils/errors.js";
 import {
@@ -595,7 +600,7 @@ export async function cancelRun(
   const sku = await detectLogicAppSku(subscriptionId, resourceGroupName, logicAppName);
 
   if (sku === "consumption") {
-    await armRequest(
+    await armRequestVoid(
       `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.Logic/workflows/${logicAppName}/runs/${runId}/cancel`,
       { method: "POST", queryParams: { "api-version": "2019-05-01" } }
     );
@@ -613,7 +618,7 @@ export async function cancelRun(
   }
 
   // For Standard, use the ARM API with hostruntime path
-  await armRequest(
+  await armRequestVoid(
     `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.Web/sites/${logicAppName}/hostruntime/runtime/webhooks/workflow/api/management/workflows/${workflowName}/runs/${runId}/cancel`,
     { method: "POST", queryParams: { "api-version": "2022-03-01" } }
   );

--- a/src/tools/triggers.ts
+++ b/src/tools/triggers.ts
@@ -2,7 +2,12 @@
  * Trigger-related tools for Logic Apps.
  */
 
-import { armRequest, armRequestAllPages, workflowMgmtRequest } from "../utils/http.js";
+import {
+  armRequest,
+  armRequestVoid,
+  armRequestAllPages,
+  workflowMgmtRequest,
+} from "../utils/http.js";
 import { McpError } from "../utils/errors.js";
 import { detectLogicAppSku, getStandardAppAccess } from "./shared.js";
 
@@ -283,7 +288,7 @@ export async function runTrigger(
   const sku = await detectLogicAppSku(subscriptionId, resourceGroupName, logicAppName);
 
   if (sku === "consumption") {
-    await armRequest(
+    await armRequestVoid(
       `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.Logic/workflows/${logicAppName}/triggers/${triggerName}/run`,
       { method: "POST", queryParams: { "api-version": "2019-05-01" } }
     );
@@ -301,7 +306,7 @@ export async function runTrigger(
   }
 
   // For Standard, use the ARM API with hostruntime path
-  await armRequest(
+  await armRequestVoid(
     `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.Web/sites/${logicAppName}/hostruntime/runtime/webhooks/workflow/api/management/workflows/${workflowName}/triggers/${triggerName}/run`,
     { method: "POST", queryParams: { "api-version": "2022-03-01" } }
   );

--- a/src/tools/workflows.ts
+++ b/src/tools/workflows.ts
@@ -2,7 +2,13 @@
  * Workflow operations for both SKUs.
  */
 
-import { armRequest, armRequestAllPages, vfsRequest, workflowMgmtRequest } from "../utils/http.js";
+import {
+  armRequest,
+  armRequestVoid,
+  armRequestAllPages,
+  vfsRequest,
+  workflowMgmtRequest,
+} from "../utils/http.js";
 import {
   ConsumptionLogicApp,
   StandardWorkflow,
@@ -351,7 +357,7 @@ export async function enableWorkflow(
   const sku = await detectLogicAppSku(subscriptionId, resourceGroupName, logicAppName);
 
   if (sku === "consumption") {
-    await armRequest(
+    await armRequestVoid(
       `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.Logic/workflows/${logicAppName}/enable`,
       { method: "POST", queryParams: { "api-version": "2019-05-01" } }
     );
@@ -399,7 +405,7 @@ export async function disableWorkflow(
   const sku = await detectLogicAppSku(subscriptionId, resourceGroupName, logicAppName);
 
   if (sku === "consumption") {
-    await armRequest(
+    await armRequestVoid(
       `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.Logic/workflows/${logicAppName}/disable`,
       { method: "POST", queryParams: { "api-version": "2019-05-01" } }
     );
@@ -696,7 +702,7 @@ export async function deleteWorkflow(
   const sku = await detectLogicAppSku(subscriptionId, resourceGroupName, logicAppName);
 
   if (sku === "consumption") {
-    await armRequest(
+    await armRequestVoid(
       `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.Logic/workflows/${logicAppName}`,
       {
         method: "DELETE",

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,5 +5,5 @@
 export { McpError, formatError } from "./errors.js";
 export type { McpErrorCode, FormattedError } from "./errors.js";
 
-export { armRequest, armRequestAllPages, workflowMgmtRequest } from "./http.js";
+export { armRequest, armRequestVoid, armRequestAllPages, workflowMgmtRequest } from "./http.js";
 export type { ArmResponse } from "./http.js";


### PR DESCRIPTION
## Summary
- Add `armRequestVoid()` function for operations that don't return data (DELETE, enable, disable, cancel, run trigger)
- `armRequest()` now throws an explicit error on empty response instead of returning `undefined as T`
- Refactored to use internal `armRequestRaw()` to avoid code duplication
- Updated callers to use `armRequestVoid` where appropriate:
  - `cancelRun()` in runs.ts
  - `enableWorkflow()`, `disableWorkflow()`, `deleteWorkflow()` in workflows.ts
  - `runTrigger()` in triggers.ts
- Fixed test file type assertions for strict TypeScript checking

## Test plan
- [x] `npm run build` passes (type-safe)
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] All 104 tests pass

Fixes #25