### PR TITLE
fix: Add UnsupportedOperation to McpErrorCode type

### DIFF
--- a/src/utils/errors.test.ts
+++ b/src/utils/errors.test.ts
@@ -24,6 +24,16 @@ describe("errors", () => {
       const error = new McpError("CustomCode", "Custom message");
       expect(error.code).toBe("CustomCode");
     });
+
+    it("should create UnsupportedOperation error", () => {
+      const error = new McpError(
+        "UnsupportedOperation",
+        "This operation is not supported for Consumption Logic Apps"
+      );
+
+      expect(error.code).toBe("UnsupportedOperation");
+      expect(error.message).toBe("This operation is not supported for Consumption Logic Apps");
+    });
   });
 
   describe("formatError", () => {

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -7,6 +7,7 @@ export type McpErrorCode =
   | "AuthorizationError"
   | "ResourceNotFound"
   | "InvalidParameter"
+  | "UnsupportedOperation"
   | "RateLimited"
   | "ServiceUnavailable"
   | "ServiceError"


### PR DESCRIPTION
## Summary
- Adds `UnsupportedOperation` to the `McpErrorCode` type definition
- This error code was already being used in `host.ts` but wasn't in the type
- Adds unit test for the new error code

## Test plan
- [x] Lint passes
- [x] Build passes  
- [x] All 105 tests pass (including new test for UnsupportedOperation)

Fixes #27