### PR TITLE
fix: Handle VFS 412/409 conflict errors with specific error code

### DIFF
--- a/src/utils/errors.test.ts
+++ b/src/utils/errors.test.ts
@@ -34,6 +34,16 @@ describe("errors", () => {
       expect(error.code).toBe("UnsupportedOperation");
       expect(error.message).toBe("This operation is not supported for Consumption Logic Apps");
     });
+
+    it("should create ConflictError for concurrent modifications", () => {
+      const error = new McpError(
+        "ConflictError",
+        "Resource was modified by another process. Please retry the operation."
+      );
+
+      expect(error.code).toBe("ConflictError");
+      expect(error.message).toBe("Resource was modified by another process. Please retry the operation.");
+    });
   });
 
   describe("formatError", () => {

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -8,6 +8,7 @@ export type McpErrorCode =
   | "ResourceNotFound"
   | "InvalidParameter"
   | "UnsupportedOperation"
+  | "ConflictError"
   | "RateLimited"
   | "ServiceUnavailable"
   | "ServiceError"

--- a/src/utils/http.test.ts
+++ b/src/utils/http.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { vfsRequest } from "./http.js";
+import { McpError } from "./errors.js";
+
+// Mock the token manager
+vi.mock("../auth/tokenManager.js", () => ({
+  getAccessToken: vi.fn().mockResolvedValue("mock-token"),
+}));
+
+// Mock the clouds config
+vi.mock("../config/clouds.js", () => ({
+  getCloudEndpoints: vi.fn().mockReturnValue({
+    resourceManager: "https://management.azure.com",
+  }),
+}));
+
+describe("http", () => {
+  describe("vfsRequest", () => {
+    const originalFetch = global.fetch;
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    it("should throw ConflictError on 412 Precondition Failed", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 412,
+        statusText: "Precondition Failed",
+        text: vi.fn().mockResolvedValue("ETag mismatch"),
+      });
+
+      await expect(
+        vfsRequest("myapp.azurewebsites.net", "/api/vfs/workflow.json", "master-key", {
+          method: "PUT",
+          body: { definition: {} },
+        })
+      ).rejects.toThrow(McpError);
+
+      await expect(
+        vfsRequest("myapp.azurewebsites.net", "/api/vfs/workflow.json", "master-key", {
+          method: "PUT",
+          body: { definition: {} },
+        })
+      ).rejects.toThrow("Resource was modified by another process");
+    });
+
+    it("should return ConflictError code on 412", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 412,
+        statusText: "Precondition Failed",
+        text: vi.fn().mockResolvedValue(""),
+      });
+
+      try {
+        await vfsRequest("myapp.azurewebsites.net", "/api/vfs/workflow.json", "master-key", {
+          method: "PUT",
+        });
+        expect.fail("Should have thrown");
+      } catch (error) {
+        expect(error).toBeInstanceOf(McpError);
+        expect((error as McpError).code).toBe("ConflictError");
+      }
+    });
+
+    it("should throw ConflictError on 409 Conflict", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 409,
+        statusText: "Conflict",
+        text: vi.fn().mockResolvedValue("Resource already exists"),
+      });
+
+      await expect(
+        vfsRequest("myapp.azurewebsites.net", "/api/vfs/workflow.json", "master-key", {
+          method: "PUT",
+        })
+      ).rejects.toThrow(McpError);
+
+      try {
+        await vfsRequest("myapp.azurewebsites.net", "/api/vfs/workflow.json", "master-key", {
+          method: "PUT",
+        });
+      } catch (error) {
+        expect(error).toBeInstanceOf(McpError);
+        expect((error as McpError).code).toBe("ConflictError");
+        expect((error as McpError).message).toContain("Resource already exists");
+      }
+    });
+
+    it("should throw ServiceError on other error status codes", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+        text: vi.fn().mockResolvedValue("Server error details"),
+      });
+
+      try {
+        await vfsRequest("myapp.azurewebsites.net", "/api/vfs/workflow.json", "master-key", {
+          method: "GET",
+        });
+        expect.fail("Should have thrown");
+      } catch (error) {
+        expect(error).toBeInstanceOf(McpError);
+        expect((error as McpError).code).toBe("ServiceError");
+        expect((error as McpError).message).toContain("500");
+      }
+    });
+
+    it("should succeed on 200 OK", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+      });
+
+      await expect(
+        vfsRequest("myapp.azurewebsites.net", "/api/vfs/workflow.json", "master-key", {
+          method: "GET",
+        })
+      ).resolves.toBeUndefined();
+    });
+
+    it("should include If-Match header for PUT requests", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+      });
+
+      await vfsRequest("myapp.azurewebsites.net", "/api/vfs/workflow.json", "master-key", {
+        method: "PUT",
+        body: { test: true },
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://myapp.azurewebsites.net/api/vfs/workflow.json",
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            "If-Match": "*",
+          }),
+        })
+      );
+    });
+
+    it("should include If-Match header for DELETE requests", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+      });
+
+      await vfsRequest("myapp.azurewebsites.net", "/api/vfs/workflow.json", "master-key", {
+        method: "DELETE",
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://myapp.azurewebsites.net/api/vfs/workflow.json",
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            "If-Match": "*",
+          }),
+        })
+      );
+    });
+  });
+});

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -193,6 +193,17 @@ export async function vfsRequest(
 
   if (!response.ok) {
     const errorText = await response.text().catch(() => "");
+
+    // Handle conflict errors (409 Conflict, 412 Precondition Failed)
+    if (response.status === 409 || response.status === 412) {
+      throw new McpError(
+        "ConflictError",
+        response.status === 412
+          ? "Resource was modified by another process. Please retry the operation."
+          : `Conflict: ${errorText || "Resource already exists or is in a conflicting state."}`
+      );
+    }
+
     throw new McpError(
       "ServiceError",
       `VFS API error: ${response.status} ${response.statusText}${errorText ? ` - ${errorText}` : ""}`


### PR DESCRIPTION
## Summary
- Adds `ConflictError` to the `McpErrorCode` type
- Handles HTTP 412 (Precondition Failed) and 409 (Conflict) errors in `vfsRequest()` with clear messages
- Users now get actionable error messages for concurrent modification conflicts instead of generic errors

## Test plan
- [x] Lint passes
- [x] Build passes
- [x] All 133 tests pass (including 8 new tests for HTTP error handling)

Fixes #33