### PR TITLE
feat: Add batch operations for workflows and runs

### DIFF
--- a/src/tools/batch.test.ts
+++ b/src/tools/batch.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { cancelRuns, batchEnableWorkflows, batchDisableWorkflows } from "./batch.js";
+
+// Mock the underlying operations
+vi.mock("./runs.js", () => ({
+  cancelRun: vi.fn(),
+}));
+
+vi.mock("./workflows.js", () => ({
+  enableWorkflow: vi.fn(),
+  disableWorkflow: vi.fn(),
+}));
+
+describe("batch operations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("cancelRuns", () => {
+    it("should cancel multiple runs successfully", async () => {
+      const { cancelRun } = await import("./runs.js");
+      const mockCancelRun = vi.mocked(cancelRun);
+      mockCancelRun.mockResolvedValue({ success: true, message: "Cancelled" });
+
+      const result = await cancelRuns(
+        "sub-123",
+        "rg",
+        "myapp",
+        ["run-1", "run-2", "run-3"],
+        undefined,
+        5
+      );
+
+      expect(result.total).toBe(3);
+      expect(result.succeeded).toBe(3);
+      expect(result.failed).toBe(0);
+      expect(result.results).toHaveLength(3);
+      expect(result.results.every((r) => r.success)).toBe(true);
+      expect(mockCancelRun).toHaveBeenCalledTimes(3);
+    });
+
+    it("should handle partial failures", async () => {
+      const { cancelRun } = await import("./runs.js");
+      const mockCancelRun = vi.mocked(cancelRun);
+      mockCancelRun
+        .mockResolvedValueOnce({ success: true, message: "Cancelled" })
+        .mockRejectedValueOnce(new Error("Run not found"))
+        .mockResolvedValueOnce({ success: true, message: "Cancelled" });
+
+      const result = await cancelRuns("sub-123", "rg", "myapp", ["run-1", "run-2", "run-3"]);
+
+      expect(result.total).toBe(3);
+      expect(result.succeeded).toBe(2);
+      expect(result.failed).toBe(1);
+
+      const failedResult = result.results.find((r) => !r.success);
+      expect(failedResult?.error).toContain("Run not found");
+    });
+
+    it("should pass workflowName for Standard SKU", async () => {
+      const { cancelRun } = await import("./runs.js");
+      const mockCancelRun = vi.mocked(cancelRun);
+      mockCancelRun.mockResolvedValue({ success: true, message: "Cancelled" });
+
+      await cancelRuns("sub-123", "rg", "myapp", ["run-1"], "workflow1");
+
+      expect(mockCancelRun).toHaveBeenCalledWith(
+        "sub-123",
+        "rg",
+        "myapp",
+        "run-1",
+        "workflow1"
+      );
+    });
+
+    it("should handle empty run array", async () => {
+      const result = await cancelRuns("sub-123", "rg", "myapp", []);
+
+      expect(result.total).toBe(0);
+      expect(result.succeeded).toBe(0);
+      expect(result.failed).toBe(0);
+      expect(result.results).toHaveLength(0);
+    });
+  });
+
+  describe("batchEnableWorkflows", () => {
+    it("should enable multiple workflows successfully", async () => {
+      const { enableWorkflow } = await import("./workflows.js");
+      const mockEnableWorkflow = vi.mocked(enableWorkflow);
+      mockEnableWorkflow.mockResolvedValue({ success: true, message: "Enabled" });
+
+      const result = await batchEnableWorkflows(
+        "sub-123",
+        "rg",
+        "myapp",
+        ["workflow1", "workflow2"]
+      );
+
+      expect(result.total).toBe(2);
+      expect(result.succeeded).toBe(2);
+      expect(result.failed).toBe(0);
+      expect(mockEnableWorkflow).toHaveBeenCalledTimes(2);
+    });
+
+    it("should handle partial failures", async () => {
+      const { enableWorkflow } = await import("./workflows.js");
+      const mockEnableWorkflow = vi.mocked(enableWorkflow);
+      mockEnableWorkflow
+        .mockResolvedValueOnce({ success: true, message: "Enabled" })
+        .mockRejectedValueOnce(new Error("Workflow not found"));
+
+      const result = await batchEnableWorkflows(
+        "sub-123",
+        "rg",
+        "myapp",
+        ["workflow1", "workflow2"]
+      );
+
+      expect(result.total).toBe(2);
+      expect(result.succeeded).toBe(1);
+      expect(result.failed).toBe(1);
+    });
+
+    it("should use default concurrency of 5", async () => {
+      const { enableWorkflow } = await import("./workflows.js");
+      const mockEnableWorkflow = vi.mocked(enableWorkflow);
+
+      // Track concurrent calls
+      let maxConcurrent = 0;
+      let currentConcurrent = 0;
+
+      mockEnableWorkflow.mockImplementation(async () => {
+        currentConcurrent++;
+        maxConcurrent = Math.max(maxConcurrent, currentConcurrent);
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        currentConcurrent--;
+        return { success: true, message: "Enabled" };
+      });
+
+      await batchEnableWorkflows(
+        "sub-123",
+        "rg",
+        "myapp",
+        ["w1", "w2", "w3", "w4", "w5", "w6", "w7", "w8", "w9", "w10"]
+      );
+
+      // Should not exceed default concurrency of 5
+      expect(maxConcurrent).toBeLessThanOrEqual(5);
+    });
+  });
+
+  describe("batchDisableWorkflows", () => {
+    it("should disable multiple workflows successfully", async () => {
+      const { disableWorkflow } = await import("./workflows.js");
+      const mockDisableWorkflow = vi.mocked(disableWorkflow);
+      mockDisableWorkflow.mockResolvedValue({ success: true, message: "Disabled" });
+
+      const result = await batchDisableWorkflows(
+        "sub-123",
+        "rg",
+        "myapp",
+        ["workflow1", "workflow2", "workflow3"]
+      );
+
+      expect(result.total).toBe(3);
+      expect(result.succeeded).toBe(3);
+      expect(result.failed).toBe(0);
+      expect(mockDisableWorkflow).toHaveBeenCalledTimes(3);
+    });
+
+    it("should handle all failures", async () => {
+      const { disableWorkflow } = await import("./workflows.js");
+      const mockDisableWorkflow = vi.mocked(disableWorkflow);
+      mockDisableWorkflow.mockRejectedValue(new Error("Service unavailable"));
+
+      const result = await batchDisableWorkflows(
+        "sub-123",
+        "rg",
+        "myapp",
+        ["workflow1", "workflow2"]
+      );
+
+      expect(result.total).toBe(2);
+      expect(result.succeeded).toBe(0);
+      expect(result.failed).toBe(2);
+      expect(result.results.every((r) => !r.success)).toBe(true);
+      expect(result.results.every((r) => r.error?.includes("Service unavailable"))).toBe(true);
+    });
+
+    it("should respect custom concurrency", async () => {
+      const { disableWorkflow } = await import("./workflows.js");
+      const mockDisableWorkflow = vi.mocked(disableWorkflow);
+
+      let maxConcurrent = 0;
+      let currentConcurrent = 0;
+
+      mockDisableWorkflow.mockImplementation(async () => {
+        currentConcurrent++;
+        maxConcurrent = Math.max(maxConcurrent, currentConcurrent);
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        currentConcurrent--;
+        return { success: true, message: "Disabled" };
+      });
+
+      await batchDisableWorkflows(
+        "sub-123",
+        "rg",
+        "myapp",
+        ["w1", "w2", "w3", "w4", "w5", "w6"],
+        2 // Custom concurrency of 2
+      );
+
+      expect(maxConcurrent).toBeLessThanOrEqual(2);
+    });
+  });
+});

--- a/src/tools/batch.ts
+++ b/src/tools/batch.ts
@@ -1,0 +1,182 @@
+/**
+ * Batch operations for Logic Apps workflows and runs.
+ * Uses controlled concurrency to avoid Azure throttling.
+ */
+
+import { cancelRun } from "./runs.js";
+import { enableWorkflow, disableWorkflow } from "./workflows.js";
+
+// ============================================================================
+// Concurrency Control
+// ============================================================================
+
+/**
+ * Execute promises with controlled concurrency.
+ * @param items Items to process
+ * @param fn Async function to apply to each item
+ * @param concurrency Maximum concurrent operations (default: 5)
+ */
+async function withConcurrency<T, R>(
+  items: T[],
+  fn: (item: T) => Promise<R>,
+  concurrency: number = 5
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  const executing: Set<Promise<void>> = new Set();
+
+  for (let i = 0; i < items.length; i++) {
+    const index = i;
+    const item = items[i];
+
+    const promise = fn(item).then((result) => {
+      results[index] = result;
+      executing.delete(promise);
+    });
+
+    executing.add(promise);
+
+    if (executing.size >= concurrency) {
+      await Promise.race(executing);
+    }
+  }
+
+  // Wait for remaining promises
+  await Promise.all(executing);
+
+  return results;
+}
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface BatchItemResult {
+  id: string;
+  success: boolean;
+  error?: string;
+}
+
+interface BatchResult {
+  total: number;
+  succeeded: number;
+  failed: number;
+  results: BatchItemResult[];
+}
+
+// ============================================================================
+// Batch Operations
+// ============================================================================
+
+/**
+ * Cancel multiple workflow runs.
+ */
+export async function cancelRuns(
+  subscriptionId: string,
+  resourceGroupName: string,
+  logicAppName: string,
+  runIds: string[],
+  workflowName?: string,
+  concurrency: number = 5
+): Promise<BatchResult> {
+  const results = await withConcurrency(
+    runIds,
+    async (runId): Promise<BatchItemResult> => {
+      try {
+        await cancelRun(subscriptionId, resourceGroupName, logicAppName, runId, workflowName);
+        return { id: runId, success: true };
+      } catch (error) {
+        return {
+          id: runId,
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    },
+    concurrency
+  );
+
+  const succeeded = results.filter((r) => r.success).length;
+
+  return {
+    total: runIds.length,
+    succeeded,
+    failed: runIds.length - succeeded,
+    results,
+  };
+}
+
+/**
+ * Enable multiple workflows.
+ * For Standard SKU, provide workflowNames. For Consumption, provide logicAppNames.
+ */
+export async function batchEnableWorkflows(
+  subscriptionId: string,
+  resourceGroupName: string,
+  logicAppName: string,
+  workflowNames: string[],
+  concurrency: number = 5
+): Promise<BatchResult> {
+  const results = await withConcurrency(
+    workflowNames,
+    async (workflowName): Promise<BatchItemResult> => {
+      try {
+        await enableWorkflow(subscriptionId, resourceGroupName, logicAppName, workflowName);
+        return { id: workflowName, success: true };
+      } catch (error) {
+        return {
+          id: workflowName,
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    },
+    concurrency
+  );
+
+  const succeeded = results.filter((r) => r.success).length;
+
+  return {
+    total: workflowNames.length,
+    succeeded,
+    failed: workflowNames.length - succeeded,
+    results,
+  };
+}
+
+/**
+ * Disable multiple workflows.
+ * For Standard SKU, provide workflowNames. For Consumption, provide logicAppNames.
+ */
+export async function batchDisableWorkflows(
+  subscriptionId: string,
+  resourceGroupName: string,
+  logicAppName: string,
+  workflowNames: string[],
+  concurrency: number = 5
+): Promise<BatchResult> {
+  const results = await withConcurrency(
+    workflowNames,
+    async (workflowName): Promise<BatchItemResult> => {
+      try {
+        await disableWorkflow(subscriptionId, resourceGroupName, logicAppName, workflowName);
+        return { id: workflowName, success: true };
+      } catch (error) {
+        return {
+          id: workflowName,
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    },
+    concurrency
+  );
+
+  const succeeded = results.filter((r) => r.success).length;
+
+  return {
+    total: workflowNames.length,
+    succeeded,
+    failed: workflowNames.length - succeeded,
+    results,
+  };
+}

--- a/src/tools/definitions.test.ts
+++ b/src/tools/definitions.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from "vitest";
 import { TOOL_DEFINITIONS } from "./definitions.js";
 
 describe("tool definitions", () => {
-  it("should have all 37 tools defined", () => {
-    expect(TOOL_DEFINITIONS).toHaveLength(37);
+  it("should have all 40 tools defined", () => {
+    expect(TOOL_DEFINITIONS).toHaveLength(40);
   });
 
   it("should have unique tool names", () => {

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -951,6 +951,106 @@ export const TOOL_DEFINITIONS: Tool[] = [
     },
   },
   {
+    name: "cancel_runs",
+    description:
+      "Cancel multiple workflow runs in a single operation. Uses controlled concurrency to avoid Azure throttling. Returns results for each run showing success or failure. For Standard SKU, workflowName is required.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        subscriptionId: {
+          type: "string",
+          description: "Azure subscription ID",
+        },
+        resourceGroupName: {
+          type: "string",
+          description: "Resource group name",
+        },
+        logicAppName: {
+          type: "string",
+          description: "Logic App resource name",
+        },
+        runIds: {
+          type: "array",
+          items: { type: "string" },
+          description: "Array of run IDs to cancel",
+        },
+        workflowName: {
+          type: "string",
+          description: "Workflow name (required for Standard SKU)",
+        },
+        concurrency: {
+          type: "number",
+          description: "Maximum concurrent operations (default: 5)",
+        },
+      },
+      required: ["subscriptionId", "resourceGroupName", "logicAppName", "runIds"],
+    },
+  },
+  {
+    name: "batch_enable_workflows",
+    description:
+      "Enable multiple workflows in a single operation. For Standard SKU, provide workflow names within the Logic App. Uses controlled concurrency to avoid Azure throttling. Returns results for each workflow showing success or failure.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        subscriptionId: {
+          type: "string",
+          description: "Azure subscription ID",
+        },
+        resourceGroupName: {
+          type: "string",
+          description: "Resource group name",
+        },
+        logicAppName: {
+          type: "string",
+          description: "Logic App resource name",
+        },
+        workflowNames: {
+          type: "array",
+          items: { type: "string" },
+          description: "Array of workflow names to enable",
+        },
+        concurrency: {
+          type: "number",
+          description: "Maximum concurrent operations (default: 5)",
+        },
+      },
+      required: ["subscriptionId", "resourceGroupName", "logicAppName", "workflowNames"],
+    },
+  },
+  {
+    name: "batch_disable_workflows",
+    description:
+      "Disable multiple workflows in a single operation. For Standard SKU, provide workflow names within the Logic App. Uses controlled concurrency to avoid Azure throttling. Returns results for each workflow showing success or failure.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        subscriptionId: {
+          type: "string",
+          description: "Azure subscription ID",
+        },
+        resourceGroupName: {
+          type: "string",
+          description: "Resource group name",
+        },
+        logicAppName: {
+          type: "string",
+          description: "Logic App resource name",
+        },
+        workflowNames: {
+          type: "array",
+          items: { type: "string" },
+          description: "Array of workflow names to disable",
+        },
+        concurrency: {
+          type: "number",
+          description: "Maximum concurrent operations (default: 5)",
+        },
+      },
+      required: ["subscriptionId", "resourceGroupName", "logicAppName", "workflowNames"],
+    },
+  },
+  {
     name: "create_workflow",
     description:
       "Create a new workflow. For Consumption SKU, creates a new Logic App resource. For Standard SKU, creates a new workflow within an existing Logic App. Requires a valid workflow definition JSON that follows the Logic Apps schema. IMPORTANT: When adding connector actions (e.g., SQL, Service Bus, MSN Weather), use get_connector_swagger first to discover the correct action paths and schemas. For Consumption SKU with connector actions, use the 'connections' parameter to wire up API connections.",

--- a/src/tools/handler.ts
+++ b/src/tools/handler.ts
@@ -46,6 +46,7 @@ import {
   getReference,
   getWorkflowInstructions,
 } from "./knowledge.js";
+import { cancelRuns, batchEnableWorkflows, batchDisableWorkflows } from "./batch.js";
 import { McpError, formatError } from "../utils/errors.js";
 
 export async function handleToolCall(
@@ -317,6 +318,34 @@ export async function handleToolCall(
           args.logicAppName as string,
           args.runId as string,
           args.workflowName as string | undefined
+        );
+        break;
+      case "cancel_runs":
+        result = await cancelRuns(
+          args.subscriptionId as string,
+          args.resourceGroupName as string,
+          args.logicAppName as string,
+          args.runIds as string[],
+          args.workflowName as string | undefined,
+          args.concurrency as number | undefined
+        );
+        break;
+      case "batch_enable_workflows":
+        result = await batchEnableWorkflows(
+          args.subscriptionId as string,
+          args.resourceGroupName as string,
+          args.logicAppName as string,
+          args.workflowNames as string[],
+          args.concurrency as number | undefined
+        );
+        break;
+      case "batch_disable_workflows":
+        result = await batchDisableWorkflows(
+          args.subscriptionId as string,
+          args.resourceGroupName as string,
+          args.logicAppName as string,
+          args.workflowNames as string[],
+          args.concurrency as number | undefined
         );
         break;
       case "create_workflow":


### PR DESCRIPTION
## Summary

- Add `cancel_runs` tool to cancel multiple workflow runs at once
- Add `batch_enable_workflows` tool to enable multiple workflows
- Add `batch_disable_workflows` tool to disable multiple workflows
- Implement controlled concurrency (default: 5) to avoid Azure throttling
- Handle partial failures gracefully with detailed per-item results

## Implementation

Uses a custom `withConcurrency()` utility that limits parallel execution while maintaining result order. Each batch operation returns:
```json
{
  "total": 10,
  "succeeded": 8,
  "failed": 2,
  "results": [
    { "id": "run-1", "success": true },
    { "id": "run-2", "success": false, "error": "Not found" },
    ...
  ]
}
```

## Test plan

- [x] All 153 tests pass (10 new batch operation tests)
- [x] Build succeeds
- [ ] Manual testing with real Azure resources

Fixes #31