### PR TITLE
fix: use POST method for Standard expression traces endpoint

### DIFF
--- a/src/tools/expressions.ts
+++ b/src/tools/expressions.ts
@@ -102,11 +102,12 @@ async function getExpressionTracesStandard(
     logicAppName
   );
 
-  // Standard uses workflow management API
+  // Standard uses workflow management API - listExpressionTraces is a POST endpoint
   const response = await workflowMgmtRequest<{ inputs?: ExpressionTraceEntry[] }>(
     hostname,
     `/runtime/webhooks/workflow/api/management/workflows/${workflowName}/runs/${runId}/actions/${actionName}/listExpressionTraces?api-version=2020-05-01-preview`,
-    masterKey
+    masterKey,
+    { method: "POST" }
   );
 
   const traces = response.inputs ?? [];


### PR DESCRIPTION
Fixes #69

## Problem
The listExpressionTraces endpoint requires POST method but workflowMgmtRequest was using GET (default), causing 404/405 errors for Standard Logic Apps.

## Fix
Pass method: POST to workflowMgmtRequest.

## Testing
- All 163 unit tests pass
