### PR TITLE
fix: propagate auth/network errors in Standard SKU detection (#74)

### DIFF
--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -141,8 +141,11 @@ async function detectSkuFromApi(
     if (site.kind?.toLowerCase().includes("workflowapp")) {
       return "standard";
     }
-  } catch {
-    // Not found
+  } catch (error) {
+    // Only ignore ResourceNotFound, propagate auth/network errors
+    if (!(error instanceof McpError && error.code === "ResourceNotFound")) {
+      throw error;
+    }
   }
 
   throw new McpError(


### PR DESCRIPTION
## Summary
Fixes #74

## Problem
The empty catch block in `shared.ts` during Standard SKU detection silently swallows all errors including authentication failures, network errors, and rate limits. This makes debugging difficult when real errors occur.

## Solution
Updated the catch block to only ignore `ResourceNotFound` errors (expected when Logic App is not Standard SKU) and propagate all other errors.

## Changes
- Modified catch block in `fetchStandardAppDetails()` to check error type
- Only `McpError` with code `ResourceNotFound` is ignored
- All other errors (auth, network, rate limits) are now properly propagated

## Testing
- All unit tests pass
- Build succeeds
