### PR TITLE
fix: add null check for api.name in getConnections (#72)

### DIFF
--- a/src/tools/connections.ts
+++ b/src/tools/connections.ts
@@ -32,7 +32,7 @@ export async function getConnections(
     connections: connections.map((conn) => ({
       id: conn.id,
       name: conn.name,
-      apiName: conn.properties.api.name,
+      apiName: conn.properties.api?.name ?? "unknown",
       displayName: conn.properties.displayName,
       status: conn.properties.statuses?.[0]?.status ?? "Unknown",
       createdTime: conn.properties.createdTime,


### PR DESCRIPTION
Fixes #72

Added optional chaining for `conn.properties.api?.name` to prevent runtime error when a connection has malformed API property.
