### PR TITLE
fix: read version from package.json instead of hardcoding (#71)

### DIFF
--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -23,6 +23,7 @@ import {
   setPassthroughToken,
   clearPassthroughToken,
 } from "../auth/index.js";
+import { VERSION } from "../version.js";
 
 let initialized = false;
 
@@ -43,7 +44,7 @@ async function ensureInitialized(): Promise<void> {
  */
 function createMcpServer(): McpServer {
   const mcpServer = new McpServer(
-    { name: "logicapps-mcp", version: "0.2.0" },
+    { name: "logicapps-mcp", version: VERSION },
     { capabilities: { tools: {}, prompts: {} } }
   );
   registerToolsAndPrompts(mcpServer);
@@ -207,6 +208,6 @@ app.http("health", {
   route: "health",
   handler: async () => ({
     status: 200,
-    jsonBody: { status: "ok", version: "0.2.0" },
+    jsonBody: { status: "ok", version: VERSION },
   }),
 });

--- a/src/http/index.ts
+++ b/src/http/index.ts
@@ -13,6 +13,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { registerToolsAndPrompts } from "../server.js";
 import { loadSettings } from "../config/index.js";
 import { setSettings, initializeAuth } from "../auth/index.js";
+import { VERSION } from "../version.js";
 
 let initialized = false;
 
@@ -34,7 +35,7 @@ async function ensureInitialized(): Promise<void> {
  */
 function createMcpServer(): McpServer {
   const mcpServer = new McpServer(
-    { name: "logicapps-mcp", version: "0.2.0" },
+    { name: "logicapps-mcp", version: VERSION },
     { capabilities: { tools: {}, prompts: {} } }
   );
   registerToolsAndPrompts(mcpServer);
@@ -102,7 +103,7 @@ export function createMcpApp(): express.Application {
 
   // Health check endpoint
   app.get("/health", (_req, res) => {
-    res.json({ status: "ok", version: "0.2.0" });
+    res.json({ status: "ok", version: VERSION });
   });
 
   // MCP endpoints

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { loadSettings } from "./config/index.js";
 import { setSettings, initializeAuth } from "./auth/index.js";
 import { registerToolsAndPrompts } from "./server.js";
+import { VERSION } from "./version.js";
 
 /**
  * Run MCP server in stdio mode (for local MCP clients).
@@ -28,7 +29,7 @@ async function runStdioMode(): Promise<void> {
   await initializeAuth();
 
   const mcpServer = new McpServer(
-    { name: "logicapps-mcp", version: "0.2.0" },
+    { name: "logicapps-mcp", version: VERSION },
     { capabilities: { tools: {}, prompts: {} } }
   );
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,39 @@
+/**
+ * Package version - read from package.json at build time.
+ * This avoids hardcoding the version in multiple places.
+ */
+
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+
+function getPackageVersion(): string {
+  try {
+    // Get the directory of this file (dist/src/ after build)
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+
+    // Navigate up to find package.json (could be 2 or 3 levels up)
+    const paths = [
+      join(__dirname, "..", "package.json"), // src/ -> root
+      join(__dirname, "..", "..", "package.json"), // dist/src/ -> root
+    ];
+
+    for (const pkgPath of paths) {
+      try {
+        const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+        if (pkg.version) {
+          return pkg.version;
+        }
+      } catch {
+        // Try next path
+      }
+    }
+
+    return "0.0.0"; // Fallback
+  } catch {
+    return "0.0.0"; // Fallback
+  }
+}
+
+export const VERSION = getPackageVersion();


### PR DESCRIPTION
Fixes #71

## Changes
- Added `src/version.ts` that reads version from package.json
- Updated `src/index.ts`, `src/http/index.ts`, and `src/functions/index.ts` to use the shared VERSION constant
- No more hardcoded version strings that can get out of sync
