### PR TITLE
fix: wrap JSON.parse in try/catch with McpError (#73)

### DIFF
--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -157,7 +157,14 @@ export async function armRequest<T>(
     throw new McpError("ServiceError", "Unexpected empty response body when data was expected");
   }
 
-  return JSON.parse(text) as T;
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    throw new McpError(
+      "InvalidResponse",
+      `Failed to parse JSON response: ${text.slice(0, 200)}${text.length > 200 ? "..." : ""}`
+    );
+  }
 }
 
 /**


### PR DESCRIPTION
Fixes #73

## Problem
`JSON.parse` in `armRequest` was called without try/catch. Malformed JSON responses from Azure APIs would cause unhandled exceptions.

## Solution
Wrapped `JSON.parse` in try/catch and throw `McpError` with `InvalidResponse` code, including a truncated preview of the malformed response for debugging.
