### PR TITLE
fix: remove unsafe non-null assertion in clearCache (#58)

### DIFF
--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -126,8 +126,13 @@ export function clearCache(
     return;
   }
 
+  // Validate: if logicAppName is provided, resourceGroupName is required
+  if (logicAppName && !resourceGroupName) {
+    throw new Error("resourceGroupName is required when logicAppName is provided");
+  }
+
   const prefix = logicAppName
-    ? getCacheKey(subscriptionId, resourceGroupName!, logicAppName)
+    ? getCacheKey(subscriptionId, resourceGroupName ?? "", logicAppName)
     : `${subscriptionId}/${resourceGroupName ?? ""}`.toLowerCase();
 
   skuCache.deleteByPrefix(prefix);


### PR DESCRIPTION
Fixes #58

## Problem
`clearCache()` used unsafe non-null assertion (`resourceGroupName!`) that could cause runtime error if `logicAppName` is provided but `resourceGroupName` is undefined.

## Solution
- Added validation: throw clear error if `logicAppName` is provided without `resourceGroupName`
- Replaced `!` assertion with `?? ""` for null coalescing
