### PR TITLE
fix: add pagination for Standard requestHistory and run actions (#106, #107)

### DIFF
--- a/pr-body.md
+++ b/pr-body.md
@@ -1,23 +1,8 @@
-Adds tools to clone Consumption Logic Apps to Standard Logic Apps using the official Logic Apps clone API.
+Fixes #58
 
-## New Tools
-- `clone_workflow` - Clone a Consumption workflow to a Standard Logic App
-- `validate_clone_workflow` - Validate compatibility before cloning
+## Problem
+`clearCache()` used unsafe non-null assertion (`resourceGroupName!`) that could cause runtime error if `logicAppName` is provided but `resourceGroupName` is undefined.
 
-## Implementation
-- Calls official `POST /workflows/{name}/clone` and `/validateClone` ARM APIs
-- No manual VFS or definition manipulation - the service handles everything
-
-## Testing
-- Unit tests (10 tests) - verify correct API calls and request bodies
-- Integration tests (6 tests) - real Azure calls that created actual workflows
-
-## Documentation
-- Updated docs/TOOLS.md with new tools
-- Updated knowledge/reference/tool-catalog.md
-- Created knowledge/operations/clone.md referencing official Microsoft docs
-
-## Notes
-- Clone only works Consumption -> Standard (not reverse)
-- Target Standard Logic App must already exist
-- API connections require reconfiguration after cloning
+## Solution
+- Added validation: throw clear error if `logicAppName` is provided without `resourceGroupName`
+- Replaced `!` assertion with `?? ""` for null coalescing

--- a/src/tools/requestHistory.ts
+++ b/src/tools/requestHistory.ts
@@ -2,7 +2,7 @@
  * Action request history tools for debugging HTTP connector calls.
  */
 
-import { armRequest, armRequestAllPages, workflowMgmtRequest } from "../utils/http.js";
+import { armRequest, armRequestAllPages, workflowMgmtRequest, workflowMgmtRequestAllPages } from "../utils/http.js";
 import { McpError } from "../utils/errors.js";
 import { detectLogicAppSku, getStandardAppAccess } from "./shared.js";
 
@@ -161,11 +161,12 @@ async function getRequestHistoryStandard(
     };
   }
 
-  const response = await workflowMgmtRequest<{
-    value?: RequestHistoryEntry[];
-  }>(hostname, `${basePath}?api-version=2020-05-01-preview`, masterKey);
-
-  const entries = response.value ?? [];
+  // Use paginated request to handle actions with many retries
+  const entries = await workflowMgmtRequestAllPages<RequestHistoryEntry>(
+    hostname,
+    `${basePath}?api-version=2020-05-01-preview`,
+    masterKey
+  );
 
   return {
     actionName,

--- a/src/tools/runs.ts
+++ b/src/tools/runs.ts
@@ -7,6 +7,7 @@ import {
   armRequestVoid,
   armRequestAllPages,
   workflowMgmtRequest,
+  workflowMgmtRequestAllPages,
 } from "../utils/http.js";
 import { WorkflowRun, RunAction, ConsumptionLogicApp } from "../types/logicApp.js";
 import { McpError } from "../utils/errors.js";
@@ -363,13 +364,12 @@ async function getRunActionsStandard(
     };
   }
 
-  const response = await workflowMgmtRequest<{ value?: RunAction[] }>(
+  // Use paginated request to handle workflows with >100 actions
+  const actionsList = await workflowMgmtRequestAllPages<RunAction>(
     hostname,
     `${basePath}?api-version=2020-05-01-preview`,
     masterKey
   );
-
-  const actionsList = response.value ?? [];
 
   return {
     actions: actionsList.map((action) => ({


### PR DESCRIPTION
Fixes #106 and #107

## Problem
- `getRequestHistoryStandard` didn't follow `nextLink` pagination
- `getRunActionsStandard` didn't follow `nextLink` pagination

## Impact
- Request histories with >100 entries (many retries) were truncated
- Workflows with >100 actions had incomplete action lists

## Solution
Use `workflowMgmtRequestAllPages` instead of `workflowMgmtRequest` for list endpoints, matching the pattern already used in `repetitions.ts`.

## Changes
- `src/tools/requestHistory.ts`: Use paginated request for Standard SKU
- `src/tools/runs.ts`: Use paginated request for Standard run actions
