### PR TITLE
fix: apply cache TTL from settings during initialization

### DIFF
--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -23,6 +23,7 @@ import {
   setPassthroughToken,
   clearPassthroughToken,
 } from "../auth/index.js";
+import { setCacheTtl } from "../tools/index.js";
 import { VERSION } from "../version.js";
 
 let initialized = false;
@@ -35,6 +36,7 @@ async function ensureInitialized(): Promise<void> {
 
   const settings = await loadSettings();
   setSettings(settings);
+  setCacheTtl(settings.cacheTtlSeconds);
   await initializeAuth();
   initialized = true;
 }

--- a/src/http/index.ts
+++ b/src/http/index.ts
@@ -13,6 +13,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { registerToolsAndPrompts } from "../server.js";
 import { loadSettings } from "../config/index.js";
 import { setSettings, initializeAuth } from "../auth/index.js";
+import { setCacheTtl } from "../tools/index.js";
 import { VERSION } from "../version.js";
 
 let initialized = false;
@@ -25,6 +26,7 @@ async function ensureInitialized(): Promise<void> {
 
   const settings = await loadSettings();
   setSettings(settings);
+  setCacheTtl(settings.cacheTtlSeconds);
   await initializeAuth();
   initialized = true;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { loadSettings } from "./config/index.js";
 import { setSettings, initializeAuth } from "./auth/index.js";
+import { setCacheTtl } from "./tools/index.js";
 import { registerToolsAndPrompts } from "./server.js";
 import { VERSION } from "./version.js";
 
@@ -26,6 +27,7 @@ import { VERSION } from "./version.js";
 async function runStdioMode(): Promise<void> {
   const settings = await loadSettings();
   setSettings(settings);
+  setCacheTtl(settings.cacheTtlSeconds);
   await initializeAuth();
 
   const mcpServer = new McpServer(

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -60,3 +60,5 @@ export type { GetExpressionTracesResult } from "./expressions.js";
 
 export { getWorkflowSwagger } from "./swagger.js";
 export type { GetWorkflowSwaggerResult } from "./swagger.js";
+
+export { setCacheTtl } from "./shared.js";


### PR DESCRIPTION
## Summary
The \setCacheTtl()\ function was exported from \shared.ts\ but never called, so the \LOGICAPPS_MCP_CACHE_TTL\ environment variable had no effect.

## Changes
- Export \setCacheTtl\ from \	ools/index.ts\
- Call \setCacheTtl(settings.cacheTtlSeconds)\ in all 3 entry points:
  - \src/index.ts\ (stdio mode)
  - \src/http/index.ts\ (HTTP mode)  
  - \src/functions/index.ts\ (Azure Functions mode)

## Testing
- All 163 unit tests pass
- No TypeScript errors

Fixes #114