### PR TITLE
fix: add empty body to POST endpoints and use retry logic for connection tests

### DIFF
--- a/src/tools/connections.ts
+++ b/src/tools/connections.ts
@@ -2,7 +2,7 @@
  * API Connection operations.
  */
 
-import { armRequest, armRequestAllPages } from "../utils/http.js";
+import { armRequest, armRequestAllPages, fetchWithRetry } from "../utils/http.js";
 import { ApiConnection } from "../types/logicApp.js";
 import { getAccessToken } from "../auth/tokenManager.js";
 import { getCloudEndpoints } from "../config/clouds.js";
@@ -156,7 +156,7 @@ export async function testConnection(
     try {
       // The testLink requestUri is a relative path
       const url = `${cloud.resourceManager}${testLink.requestUri}`;
-      const response = await fetch(url, {
+      const response = await fetchWithRetry(url, {
         method: testLink.method,
         headers: {
           Authorization: `Bearer ${token}`,

--- a/src/tools/expressions.ts
+++ b/src/tools/expressions.ts
@@ -107,7 +107,7 @@ async function getExpressionTracesStandard(
     hostname,
     `/runtime/webhooks/workflow/api/management/workflows/${workflowName}/runs/${runId}/actions/${actionName}/listExpressionTraces?api-version=2020-05-01-preview`,
     masterKey,
-    { method: "POST" }
+    { method: "POST", body: {} }
   );
 
   const traces = response.inputs ?? [];

--- a/src/tools/swagger.ts
+++ b/src/tools/swagger.ts
@@ -53,7 +53,7 @@ async function getSwaggerConsumption(
 ): Promise<GetWorkflowSwaggerResult> {
   const swagger = await armRequest<Record<string, unknown>>(
     `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.Logic/workflows/${logicAppName}/listSwagger`,
-    { method: "POST", queryParams: { "api-version": "2019-05-01" } }
+    { method: "POST", queryParams: { "api-version": "2019-05-01" }, body: {} }
   );
 
   return {

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -46,7 +46,7 @@ function sleep(ms: number): Promise<void> {
 /**
  * Fetch with retry logic, exponential backoff, and timeout.
  */
-async function fetchWithRetry(url: string, options: RequestInit): Promise<Response> {
+export async function fetchWithRetry(url: string, options: RequestInit): Promise<Response> {
   let lastError: Error | undefined;
 
   for (let attempt = 0; attempt <= retryConfig.maxRetries; attempt++) {


### PR DESCRIPTION
## Summary
Fixes two low-priority bugs found during code review.

## Changes

### #109: POST endpoints may need empty request body
- Added empty body to listSwagger POST request (Consumption SKU)
- Added empty body to listExpressionTraces POST request (Standard SKU)

This prevents potential 400 Bad Request errors from Azure APIs that expect a body.

### #110: testConnection does not use retry logic
- Exported fetchWithRetry from utils/http.ts
- Changed testConnection to use fetchWithRetry instead of raw fetch()

This ensures transient failures and rate limiting are properly retried during connection tests.

## Testing
- All 163 unit tests pass
- No TypeScript errors

Fixes #109, #110