### PR TITLE
fix: remove unused imports in test files

### DIFF
--- a/src/__integration__/clone.integration.test.ts
+++ b/src/__integration__/clone.integration.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect, beforeAll } from "vitest";
-import { cloneWorkflow, validateCloneWorkflow, listWorkflows } from "../tools/workflows.js";
+import { cloneWorkflow, validateCloneWorkflow } from "../tools/workflows.js";
 import { getAzureCliToken } from "../auth/azureCli.js";
 import { setPassthroughToken } from "../auth/tokenManager.js";
 

--- a/src/tools/connections.test.ts
+++ b/src/tools/connections.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createConnection } from "./connections.js";
-import { McpError } from "../utils/errors.js";
 
 // Mock the http module
 vi.mock("../utils/http.js", () => ({


### PR DESCRIPTION
## Summary

Removes unused imports that were causing ESLint errors:
- `listWorkflows` in `clone.integration.test.ts`
- `McpError` in `connections.test.ts`

## Testing
- `npm run lint` passes
- `npm test` passes (178 tests)