### PR TITLE
docs: update install command to use npm package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.4.1] - 2026-01-11
+
+### Fixed
+- Documentation: corrected install commands to use npm package name `logicapps-mcp`
+- Documentation: updated tool count from 37 to 40 (36 operations + 4 knowledge tools)
+
 ## [0.4.0] - 2026-01-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ See the [Getting Started Guide](docs/GETTING_STARTED.md) for detailed setup inst
 
 ```bash
 # 1. Install
-npm install -g github:laveeshb/logicapps-mcp
+npm install -g logicapps-mcp
 
 # 2. Login to Azure
 az login
@@ -57,7 +57,7 @@ curl -H "Authorization: Bearer $token" https://<app>.azurewebsites.net/api/healt
 
 ## Features
 
-- **37 Tools** for Logic Apps operations: list, debug, create, update, delete workflows
+- **40 Tools** for Logic Apps operations: list, debug, create, update, delete workflows
 - **Dual SKU Support**: Works with both Consumption and Standard Logic Apps
 - **Run Debugging**: Trace failures through actions, loops, and scopes
 - **Write Operations**: Create workflows, run triggers, cancel runs
@@ -76,7 +76,7 @@ curl -H "Authorization: Bearer $token" https://<app>.azurewebsites.net/api/healt
 ## Documentation
 
 - [Getting Started Guide](docs/GETTING_STARTED.md) - Setup for Claude, Copilot, Cloud MCP Server
-- [Available Tools](docs/TOOLS.md) - All 37 tools with descriptions
+- [Available Tools](docs/TOOLS.md) - All 40 tools with descriptions
 - [Configuration](docs/CONFIGURATION.md) - Environment variables, auth, SKU differences
 - [Changelog](CHANGELOG.md) - Release history
 

--- a/design/LOCAL_MCP_SERVER.md
+++ b/design/LOCAL_MCP_SERVER.md
@@ -28,10 +28,10 @@ An npm package that implements the Model Context Protocol (MCP), enabling any MC
 │                                                                             │
 │  ┌─────────────────────┐    stdio    ┌────────────────────────────────────┐│
 │  │  AI Client          │◄───────────►│  MCP Server                        ││
-│  │  (Claude/Copilot/   │             │  @laveeshb/logicapps-mcp           ││
+│  │  (Claude/Copilot/   │             │  logicapps-mcp                     ││
 │  │   Cursor/Windsurf)  │             │                                    ││
-│  │                     │             │  ├── 33 Logic Apps tools           ││
-│  │  User's LLM         │             │  ├── 3 Knowledge tools             ││
+│  │                     │             │  ├── 36 Logic Apps tools           ││
+│  │  User's LLM         │             │  ├── 4 Knowledge tools             ││
 │  │  subscription       │             │  └── Bundled docs (~3,600 lines)   ││
 │  └─────────────────────┘             └────────────────────────────────────┘│
 │                                                   │                         │
@@ -57,7 +57,7 @@ An npm package that implements the Model Context Protocol (MCP), enabling any MC
 
 | Channel | Purpose |
 |---------|---------|
-| **npm** | `@laveeshb/logicapps-mcp` - Primary distribution |
+| **npm** | `logicapps-mcp` - Primary distribution |
 | **mcp.so** | Discoverability for Claude/MCP users |
 | **Smithery.ai** | MCP registry |
 | **GitHub** | Source code, issues, documentation |
@@ -68,10 +68,10 @@ An npm package that implements the Model Context Protocol (MCP), enabling any MC
 
 ```bash
 # Via npx (recommended - always latest)
-npx -y @laveeshb/logicapps-mcp
+npx -y logicapps-mcp
 
 # Via npm global install
-npm install -g @laveeshb/logicapps-mcp
+npm install -g logicapps-mcp
 logicapps-mcp
 ```
 
@@ -92,7 +92,7 @@ Command Palette → MCP: Open User Configuration
     "logicapps": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@laveeshb/logicapps-mcp"]
+      "args": ["-y", "logicapps-mcp"]
     }
   }
 }
@@ -107,7 +107,7 @@ Command Palette → MCP: Open User Configuration
   "mcpServers": {
     "logicapps": {
       "command": "npx",
-      "args": ["-y", "@laveeshb/logicapps-mcp"]
+      "args": ["-y", "logicapps-mcp"]
     }
   }
 }
@@ -121,7 +121,7 @@ Command Palette → MCP: Open User Configuration
   "mcpServers": {
     "logicapps": {
       "command": "npx",
-      "args": ["-y", "@laveeshb/logicapps-mcp"]
+      "args": ["-y", "logicapps-mcp"]
     }
   }
 }
@@ -131,7 +131,7 @@ Command Palette → MCP: Open User Configuration
 
 ## Tool Architecture
 
-### Layer 1: Logic Apps Operations (33 tools)
+### Layer 1: Logic Apps Operations (36 tools)
 
 | Category | Tools | Description |
 |----------|-------|-------------|
@@ -194,7 +194,7 @@ export function getTroubleshootingGuide(topic: string): string {
 ## Package Structure
 
 ```
-@laveeshb/logicapps-mcp/
+logicapps-mcp/
 ├── package.json
 ├── README.md
 ├── dist/                    # Compiled TypeScript

--- a/design/README.md
+++ b/design/README.md
@@ -26,7 +26,7 @@ This document describes the design for a Logic Apps MCP Server that enables AI a
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │                        SHARED COMPONENTS                                    │
 │  ┌─────────────────────────────────────────────────────────────────────┐   │
-│  │  - 37 Tools (33 Logic Apps operations + 4 knowledge tools)          │   │
+│  │  - 40 Tools (36 Logic Apps operations + 4 knowledge tools)          │   │
 │  │  - Bundled documentation (~3,600 lines)                             │   │
 │  │  - Same TypeScript codebase                                         │   │
 │  └─────────────────────────────────────────────────────────────────────┘   │
@@ -51,7 +51,7 @@ This document describes the design for a Logic Apps MCP Server that enables AI a
 
 ### [Local MCP Server](LOCAL_MCP_SERVER.md)
 
-- npm package: `@laveeshb/logicapps-mcp`
+- npm package: `logicapps-mcp`
 - Works with: VS Code Copilot, Claude Desktop, Cursor, Windsurf
 - Distribution: npm, mcp.so, Smithery
 - Auth: Uses Azure CLI cached credentials (`az login`)
@@ -69,9 +69,9 @@ This document describes the design for a Logic Apps MCP Server that enables AI a
 
 ## Shared Tool Catalog
 
-Both solutions implement the same 37 tools:
+Both solutions implement the same 40 tools:
 
-### Logic Apps Operations (33 tools)
+### Logic Apps Operations (36 tools)
 
 | Category | Tools |
 |----------|-------|

--- a/docs/CLOUD_MCP_SERVER.md
+++ b/docs/CLOUD_MCP_SERVER.md
@@ -202,5 +202,5 @@ curl -X POST "https://<app>.azurewebsites.net/api/mcp" \
 ## See Also
 
 - [Getting Started](GETTING_STARTED.md) - Setup guides and comparison with local MCP server
-- [Available Tools](TOOLS.md) - All 37 tools available via MCP
+- [Available Tools](TOOLS.md) - All 40 tools available via MCP
 - [Configuration](CONFIGURATION.md) - Environment variables and authentication

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -56,5 +56,5 @@ For read-only access, `Logic App Reader` is sufficient.
 ## See Also
 
 - [Getting Started](GETTING_STARTED.md) - Setup guides for local MCP server or cloud agent
-- [Available Tools](TOOLS.md) - All 37 tools
+- [Available Tools](TOOLS.md) - All 40 tools
 - [Cloud MCP Server](CLOUD_MCP_SERVER.md) - Deploy to Azure for team/enterprise use

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -42,7 +42,7 @@ Both options require Azure access (az login) to get credentials.
 ### Step 1: Install
 
 ```bash
-npm install -g github:laveeshb/logicapps-mcp
+npm install -g logicapps-mcp
 ```
 
 ### Step 2: Login to Azure
@@ -87,7 +87,7 @@ Add to your Claude Desktop configuration:
   "mcpServers": {
     "logicapps": {
       "command": "npx",
-      "args": ["github:laveeshb/logicapps-mcp"]
+      "args": ["-y", "logicapps-mcp"]
     }
   }
 }
@@ -196,5 +196,5 @@ $token = (Get-AzAccessToken -ResourceUrl https://management.azure.com).Token
 
 ## Next Steps
 
-- [Available Tools](TOOLS.md) - See all 37 tools
+- [Available Tools](TOOLS.md) - See all 40 tools
 - [Configuration](CONFIGURATION.md) - Environment variables and authentication

--- a/knowledge/reference/tool-catalog.md
+++ b/knowledge/reference/tool-catalog.md
@@ -5,7 +5,7 @@ lastUpdated: 2025-12-26
 
 # Tool Catalog
 
-Complete reference for all 39 MCP tools available in `@laveeshb/logicapps-mcp`.
+Complete reference for all 40 MCP tools available in `logicapps-mcp`.
 
 **Microsoft Docs:**
 - [Logic Apps REST API reference](https://learn.microsoft.com/rest/api/logic/)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logicapps-mcp",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "MCP server for Azure Logic Apps - debug workflows, manage runs, and create automations with AI assistants",
   "author": "Laveesh Bansal <laveeshb@laveeshbansal.com>",
   "homepage": "https://github.com/laveeshb/logicapps-mcp",

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,9 +8,9 @@
  * - http: For cloud deployment (Azure Functions, standalone server)
  *
  * Usage:
- *   npx @laveeshb/logicapps-mcp          # stdio mode (default)
- *   npx @laveeshb/logicapps-mcp --http   # HTTP server mode
- *   npx @laveeshb/logicapps-mcp --http --port 8080
+ *   npx logicapps-mcp          # stdio mode (default)
+ *   npx logicapps-mcp --http   # HTTP server mode
+ *   npx logicapps-mcp --http --port 8080
  */
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";


### PR DESCRIPTION
Fix documentation issues after npm publish:

## Changes

### Install commands updated
- Changed `npm install -g github:laveeshb/logicapps-mcp` → `npm install -g logicapps-mcp`
- Changed `npx @laveeshb/logicapps-mcp` → `npx logicapps-mcp`

### Tool count updated
- Changed "37 tools" → "40 tools" (added `resubmit_run`, `clone_workflow`, `validate_clone_workflow`)
- Updated breakdown: 36 Logic Apps operations + 4 knowledge tools

## Files updated
- README.md
- src/index.ts
- docs/GETTING_STARTED.md
- docs/CONFIGURATION.md
- docs/CLOUD_MCP_SERVER.md
- design/README.md
- design/LOCAL_MCP_SERVER.md
- knowledge/reference/tool-catalog.md
