### PR TITLE
fix: include README.md in npm package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4.2] - 2026-01-11
+
+### Fixed
+- npm package now includes README.md
+
 ## [0.4.1] - 2026-01-11
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logicapps-mcp",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "MCP server for Azure Logic Apps - debug workflows, manage runs, and create automations with AI assistants",
   "author": "Laveesh Bansal <laveeshb@laveeshbansal.com>",
   "homepage": "https://github.com/laveeshb/logicapps-mcp",
@@ -11,7 +11,8 @@
   },
   "files": [
     "dist",
-    "knowledge"
+    "knowledge",
+    "README.md"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
The npm package page shows 'This package does not have a README'.

### Changes
- Added `README.md` to the `files` array in package.json
- Bumped version to 0.4.2
- Added changelog entry
