### PR TITLE
Add mcpName for official MCP Registry publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4.2] - 2026-01-11
+
+### Added
+- `mcpName` field for official MCP Registry publishing
+
 ## [0.4.1] - 2026-01-11
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "logicapps-mcp",
-  "version": "0.4.1",
+  "version": "0.4.2",
+  "mcpName": "io.github.laveeshb/logicapps-mcp",
   "description": "MCP server for Azure Logic Apps - debug workflows, manage runs, and create automations with AI assistants",
   "author": "Laveesh Bansal <laveeshb@laveeshbansal.com>",
   "homepage": "https://github.com/laveeshb/logicapps-mcp",


### PR DESCRIPTION
## Summary
Adds the mcpName field to package.json for publishing to the official MCP Registry at https://registry.modelcontextprotocol.io

## Changes
- Added mcpName: io.github.laveeshb/logicapps-mcp to package.json
- Bumped version to 0.4.2
- Updated CHANGELOG

## Why
The MCP Registry requires an mcpName field in package.json to verify package ownership. Using GitHub-based authentication, the namespace must start with io.github.laveeshb/ to match the GitHub account.