### PR TITLE
Add MCP Registry server.json and README badges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ coverage/
 # Deployment artifacts
 *.zip
 **/logicapp-logs/
+
+# MCP Publisher CLI
+mcp-publisher.exe

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Azure Logic Apps MCP Server
 
+[![MCP Registry](https://img.shields.io/badge/MCP%20Registry-io.github.laveeshb%2Flogicapps--mcp-blue)](https://registry.modelcontextprotocol.io/)
+[![npm](https://img.shields.io/npm/v/logicapps-mcp)](https://www.npmjs.com/package/logicapps-mcp)
+
 <img src="https://raw.githubusercontent.com/benc-uk/icon-collection/master/azure-icons/Logic-Apps.svg" alt="Azure Logic Apps" width="80" align="right">
 
 Manage and debug Azure Logic Apps using natural language. Ask your AI assistant to investigate failed runs, explain workflows, or make changes—no portal clicking required.

--- a/server.json
+++ b/server.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.laveeshb/logicapps-mcp",
+  "description": "MCP server for Azure Logic Apps - debug workflows, manage runs, and authoring",
+  "repository": {
+    "url": "https://github.com/laveeshb/logicapps-mcp",
+    "source": "github"
+  },
+  "version": "0.4.2",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "logicapps-mcp",
+      "version": "0.4.2",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Adds the server.json file for MCP Registry publishing and adds badges to the README.

## Changes
- Added server.json for MCP Registry (the server is already published as io.github.laveeshb/logicapps-mcp)
- Added MCP Registry and npm badges to README
- Added mcp-publisher.exe to .gitignore